### PR TITLE
Removes redundant reference to #define ARDUINO_ARCH_NRF52

### DIFF
--- a/examples/Example2_PeriodicCommunications/Example2_PeriodicCommunications.ino
+++ b/examples/Example2_PeriodicCommunications/Example2_PeriodicCommunications.ino
@@ -17,10 +17,6 @@
 #define buttonPin			7
 #define	buttonPressedState	LOW
 #define ledPin				LED_RED
-#elif defined(ARDUINO_ARCH_NRF52)
-#define buttonPin			7
-#define	buttonPressedState	LOW
-#define ledPin				LED_RED
 #elif defined(ARDUINO_ARCH_AVR)
 #define buttonPin			6
 #define	buttonPressedState	LOW


### PR DESCRIPTION
There was a #elif block repeated with the exact same information in the same file.  Removed one of the block