### PR TITLE
Fixes note-* repo links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,9 +179,9 @@ array, before adding your new entry._
 
 For additional Notecard SDKs and Libraries, see:
 
-* [note-c](note-c) for Standard C support
-* [note-go](note-go) for Go
-* [note-python](note-python) for Python
+* [note-c][note-c] for Standard C support
+* [note-go][note-go] for Go
+* [note-python][note-python] for Python
 
 ## To learn more about Blues Wireless, the Notecard and Notehub, see:
 


### PR DESCRIPTION
Can't believe I missed this one after doing all the other repos!

Fixes syntax error in reference links for the following:
- note-c
- note-go
- note-python