### PR TITLE
fix:cast i2c write of 0 to avoid compiler error from some boards

### DIFF
--- a/src/NoteI2c_Arduino.cpp
+++ b/src/NoteI2c_Arduino.cpp
@@ -43,7 +43,7 @@ NoteI2c_Arduino::receive (
     // Request response data from Notecard
     for (size_t i = 0 ; i < 3 ; ++i) {
         _i2cPort.beginTransmission(static_cast<uint8_t>(device_address_));
-        _i2cPort.write(0);
+        _i2cPort.write(static_cast<uint8_t>(0));
         _i2cPort.write(static_cast<uint8_t>(requested_byte_count_));
         transmission_error = _i2cPort.endTransmission();
 


### PR DESCRIPTION
While working on a sensor tutorial today for the SparkFun Artemis, I got a compile-time error from note-arduino when initializing I2C. 

```
error: call of overloaded 'write(int)' is ambiguous
```

The error occurs on `NoteI2c_Arduino.cpp` on line 46

```
_i2cPort.write(0);
```

Upon investigation, is seems that [certain boards](https://support.arduino.cc/hc/en-us/articles/360021722399-Error-call-of-overloaded-write-int-is-ambiguous) interpret a `0` as a `NULL` value, and the solution is to cast the value to a `byte` or, in our case, `uint8_t` to keep the unit tests happy. :D one line changed and I have verified this works with the Artemis board now.