### PR TITLE
fix:Example2 does not compile for Swan due to a missing directive

### DIFF
--- a/examples/Example2_PeriodicCommunications/Example2_PeriodicCommunications.ino
+++ b/examples/Example2_PeriodicCommunications/Example2_PeriodicCommunications.ino
@@ -21,6 +21,10 @@
 #define buttonPin     6
 #define buttonPressedState  LOW
 #define ledPin        4
+#elif defined(ARDUINO_ARCH_STM32)
+#define buttonPin     USER_BTN
+#define buttonPressedState  LOW
+#define ledPin        LED_BUILTIN
 #else
 #error "please add a board definition for button and led"
 #define buttonPin     ?       // Change to any GPIO pin where there is an active-high button


### PR DESCRIPTION
Example2_PeriodicCommunications.ino has a series of `#if defined` directives that assign the button pin, led pin and button state for use in the main body of the sketch. This sketch does not currently compile for swan because of missing directives. Added a defined check and pointers to the `USER_BUTTON` and `LED_BUILTIN` which are defined for all STM32duino boards.