### PR TITLE
experiment to see if post-commit hooks work with the arduino library manager

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "note-c"]
+	path = note-c
+	url = https://github.com/blues/note-c

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Blues Wireless Notecard
-version=1.3.9
+version=1.3.10
 author=Blues Wireless
 maintainer=Blues Wireless <info@blues.io>
 sentence=An easy to use Notecard Library for Arduino.


### PR DESCRIPTION
- note-c submodule added to the root - should be safe if submodules fail
- post-checkout hook added that writes to checkout.txt in the root and updates the submodule

The hope is that the post commit hook pulls in the sources for the submodule.  If any of this fails, it should hopefully not be intrusive to our users.