### PR TITLE
feat: Full abstraction of `note-cpp` from `note-arduino`

### DIFF
--- a/.github/actions/compile-examples/Dockerfile
+++ b/.github/actions/compile-examples/Dockerfile
@@ -9,7 +9,7 @@
 # docker run --entrypoint bash --interactive --rm --tty --volume "$(pwd)":/host-volume/ --workdir /host-volume/ arduino-cli
 
 # Define global arguments
-ARG ARDUINO_CLI_VERSION=0.22.0
+ARG ARDUINO_CLI_VERSION=0.23.0
 ARG DEBIAN_FRONTEND="noninteractive"
 ARG UID=1000
 ARG USER="blues"
@@ -52,6 +52,7 @@ RUN ["dash", "-c", "\
     apt-get update --quiet \
  && apt-get install --assume-yes --no-install-recommends --quiet \
      bash \
+     bash-completion \
      ca-certificates \
      curl \
      python-is-python3 \
@@ -70,14 +71,15 @@ RUN ["dash", "-c", "\
 # Download/Install Arduino CLI
 RUN ["dash", "-c", "\
     curl -fsSL https://raw.githubusercontent.com/arduino/arduino-cli/master/install.sh | BINDIR=${BINDIR} sh -s ${ARDUINO_CLI_VERSION} \
-# && arduino-cli completion bash > /usr/share/bash-completion/completions/arduino-cli.sh \
  && mkdir -p /etc/bash_completion.d/ \
  && arduino-cli completion bash > /etc/bash_completion.d/arduino-cli.sh \
  && echo >> /etc/bash.bashrc \
-# && echo \"for bcfile in /usr/share/bash-completion/completions/* ; do\" >> /etc/bash.bashrc \
-#  && echo \"for bcfile in /etc/bash_completion.d/* ; do\" >> /etc/bash.bashrc \
-#  && echo \"    [ -f \\\"${ECHO_BC_FILE}\\\" ] && . \\\"${ECHO_BC_FILE}\\\"\" >> /etc/bash.bashrc \
-#  && echo \"done\" >> /etc/bash.bashrc \
+ && echo \"for bcfile in /etc/bash_completion.d/* ; do\" >> /etc/bash.bashrc \
+ && echo \"    [ -f \\\"${ECHO_BC_FILE}\\\" ] && . \\\"${ECHO_BC_FILE}\\\"\" >> /etc/bash.bashrc \
+ && echo \"done\" >> /etc/bash.bashrc \
+ && echo \"if [ -f /etc/bash_completion ]; then\" >> /etc/bash.bashrc \
+ && echo \"    . /etc/bash_completion\" >> /etc/bash.bashrc \
+ && echo \"fi\" >> /etc/bash.bashrc \
 "]
 
 # Configure Arduino CLI

--- a/.github/actions/run-tests-in-container/Dockerfile
+++ b/.github/actions/run-tests-in-container/Dockerfile
@@ -14,6 +14,7 @@ FROM alpine:3.14
 RUN ["ash", "-c", "\
     apk add --no-cache \
       g++ \
+      gdb \
       valgrind \
 "]
 

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.gcda
 *.gcno
 *.gcov
+vgcore.*
 
 coverage/
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-.vscode/
 .DS_Store
 *.gch
 *.out

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,78 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+			"name": "Debug Failed Unit-tests",
+			"type": "cppdbg",
+			"request": "launch",
+			"program": "${workspaceRoot}/failed_test_run",
+            "args": [],
+			"cwd": "${workspaceRoot}",
+			"MIMode": "gdb",
+            "miDebuggerPath": "/usr/bin/gdb"
+		},
+        {
+			"name": "Debug Notecard Unit-tests",
+			"type": "cppdbg",
+			"request": "launch",
+			"program": "${workspaceRoot}/notecard.tests",
+            "args": [],
+			"cwd": "${workspaceRoot}",
+            "preLaunchTask": "Compile Notecard Tests",
+            "postDebugTask": "Clear Test Binaries",
+			"MIMode": "gdb",
+            "miDebuggerPath": "/usr/bin/gdb"
+		},
+        {
+			"name": "Debug NoteI2c Arduino Unit-tests",
+			"type": "cppdbg",
+			"request": "launch",
+			"program": "${workspaceRoot}/notei2c_arduino.tests",
+            "args": [],
+			"cwd": "${workspaceRoot}",
+            "preLaunchTask": "Compile NoteI2c Arduino Tests",
+            "postDebugTask": "Clear Test Binaries",
+			"MIMode": "gdb",
+            "miDebuggerPath": "/usr/bin/gdb"
+		},
+        {
+			"name": "Debug NoteI2c Arduino Unit-tests (-DWIRE_HAS_END)",
+			"type": "cppdbg",
+			"request": "launch",
+			"program": "${workspaceRoot}/notei2c_arduino_wire_has_end.tests",
+            "args": [],
+			"cwd": "${workspaceRoot}",
+            "preLaunchTask": "Compile NoteI2c Arduino Tests (-DWIRE_HAS_END)",
+            "postDebugTask": "Clear Test Binaries",
+			"MIMode": "gdb",
+            "miDebuggerPath": "/usr/bin/gdb"
+		},
+        {
+			"name": "Debug NoteLog Arduino Unit-tests",
+			"type": "cppdbg",
+			"request": "launch",
+			"program": "${workspaceRoot}/notelog_arduino.tests",
+            "args": [],
+			"cwd": "${workspaceRoot}",
+            "preLaunchTask": "Compile NoteLog Arduino Tests",
+            "postDebugTask": "Clear Test Binaries",
+			"MIMode": "gdb",
+            "miDebuggerPath": "/usr/bin/gdb"
+		},
+        {
+			"name": "Debug NoteSerial Arduino Unit-tests",
+			"type": "cppdbg",
+			"request": "launch",
+			"program": "${workspaceRoot}/noteserial_arduino.tests",
+            "args": [],
+			"cwd": "${workspaceRoot}",
+            "preLaunchTask": "Compile NoteSerial Arduino Tests",
+            "postDebugTask": "Clear Test Binaries",
+			"MIMode": "gdb",
+            "miDebuggerPath": "/usr/bin/gdb"
+		},
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "files.associations": {
+        "ostream": "cpp"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "files.associations": {
-        "ostream": "cpp"
-    }
-}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,191 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+        {
+            "type": "cppbuild",
+            "label": "Compile and Run ALL Tests",
+            "command": "./test/run_all_tests.sh",
+            "args": [],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        },
+        {
+            "type": "cppbuild",
+            "label": "Compile Notecard Tests",
+            "command": "g++",
+            "args": [
+                "-Wall",
+                "-Wextra",
+                "-Wpedantic",
+                "test/mock/mock-arduino.cpp",
+                "test/mock/mock-note-c-note.c",
+                "test/mock/NoteI2c_Mock.cpp",
+                "test/mock/NoteLog_Mock.cpp",
+                "test/mock/NoteSerial_Mock.cpp",
+                "src/Notecard.cpp",
+                "test/Notecard.test.cpp",
+                "-std=c++11",
+                "-Itest",
+                "-Isrc",
+                "-DNOTE_MOCK",
+                "-o",
+                "notecard.tests",
+                "-g",
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            }
+        },
+        {
+            "type": "cppbuild",
+            "label": "Compile NoteI2c Arduino Tests",
+            "command": "g++",
+            "args": [
+                "-Wall",
+                "-Wextra",
+                "-Wpedantic",
+                "test/mock/mock-arduino.cpp",
+                "test/mock/mock-note-c-note.c",
+                "src/NoteI2c_Arduino.cpp",
+                "test/NoteI2c_Arduino.test.cpp",
+                "-std=c++11",
+                "-Itest",
+                "-Isrc",
+                "-DNOTE_MOCK",
+                "-o",
+                "notei2c_arduino.tests",
+                "-g",
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            }
+        },
+        {
+            "type": "cppbuild",
+            "label": "Compile NoteI2c Arduino Tests (-DWIRE_HAS_END)",
+            "command": "g++",
+            "args": [
+                "-Wall",
+                "-Wextra",
+                "-Wpedantic",
+                "test/mock/mock-arduino.cpp",
+                "test/mock/mock-note-c-note.c",
+                "src/NoteI2c_Arduino.cpp",
+                "test/NoteI2c_Arduino.test.cpp",
+                "-std=c++11",
+                "-Itest",
+                "-Isrc",
+                "-DNOTE_MOCK",
+                "-DWIRE_HAS_END",
+                "-o",
+                "notei2c_arduino_wire_has_end.tests",
+                "-g",
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            }
+        },
+        {
+            "type": "cppbuild",
+            "label": "Compile NoteLog Arduino Tests",
+            "command": "g++",
+            "args": [
+                "-Wall",
+                "-Wextra",
+                "-Wpedantic",
+                "test/mock/mock-arduino.cpp",
+                "test/mock/mock-note-c-note.c",
+                "src/NoteLog_Arduino.cpp",
+                "test/NoteLog_Arduino.test.cpp",
+                "-std=c++11",
+                "-Itest",
+                "-Isrc",
+                "-DNOTE_MOCK",
+                "-o",
+                "notelog_arduino.tests",
+                "-g",
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            }
+        },
+        {
+            "type": "cppbuild",
+            "label": "Compile NoteSerial Arduino Tests",
+            "command": "g++",
+            "args": [
+                "-Wall",
+                "-Wextra",
+                "-Wpedantic",
+                "test/mock/mock-arduino.cpp",
+                "test/mock/mock-note-c-note.c",
+                "src/NoteSerial_Arduino.cpp",
+                "test/NoteSerial_Arduino.test.cpp",
+                "-std=c++11",
+                "-Itest",
+                "-Isrc",
+                "-DNOTE_MOCK",
+                "-o",
+                "noteserial_arduino.tests",
+                "-g",
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": false
+            }
+        },
+        {
+            "type": "shell",
+            "label": "Clear Test Binaries",
+            "command": "rm -rf *.tests",
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": [
+                "$gcc"
+            ],
+        },
+    ]
+}

--- a/src/Notecard.cpp
+++ b/src/Notecard.cpp
@@ -222,6 +222,7 @@ void Notecard::begin(HardwareSerial &selectedSerialPort, int selectedSpeed)
                     noteSerialAvailable, noteSerialReceive);
 }
 
+#ifdef ARDUINO
 /**************************************************************************/
 /*!
     @brief  Set the debug output source.
@@ -236,6 +237,28 @@ void Notecard::setDebugOutputStream(Stream &dbgserial)
 {
     noteLog = make_note_log(&dbgserial);
     NoteSetFnDebugOutput(noteLogPrint);
+}
+#endif
+
+/**************************************************************************/
+/*!
+    @brief  Set the debug output source.
+            A NoteLog object will be constructed via `make_note_log()`
+            using a platform specific logging channel (for example, `Serial`
+            on Arduino). The specified channel will be configured as the
+            source for debug messages provided to `notecard.logDebug()`.
+    @param    logChannel
+              A platform specific channel to be used for debug output.
+*/
+/**************************************************************************/
+void Notecard::setDebugOutputStream(NoteLog::channel_t logChannel)
+{
+    noteLog = make_note_log(logChannel);
+    if (noteLog) {
+        NoteSetFnDebugOutput(noteLogPrint);
+    } else {
+        NoteSetFnDebugOutput(nullptr);
+    }
 }
 
 /**************************************************************************/
@@ -252,7 +275,7 @@ void Notecard::clearDebugOutputStream()
 /*!
     @brief  Creates a new request object for population by the host.
             This function accepts a request string (for example, `"note.add"`)
-      and initializes a JSON Object to return to the host.
+            and initializes a JSON Object to return to the host.
     @param    request
               The request name, for example, `note.add`.
     @return A `J` JSON Object populated with the request name.
@@ -267,7 +290,7 @@ J *Notecard::newRequest(const char *request)
 /*!
     @brief  Creates a new command object for population by the host.
             This function accepts a command string (for example, `"note.add"`)
-      and initializes a JSON Object to return to the host.
+            and initializes a JSON Object to return to the host.
     @param    request
               The command name, for example, `note.add`.
     @return A `J` JSON Object populated with the request name.
@@ -282,11 +305,11 @@ J *Notecard::newCommand(const char *request)
 /*!
     @brief  Sends a request to the Notecard.
             This function takes a populated `J` JSON request object
-      and sends it to the Notecard.
+            and sends it to the Notecard.
     @param    req
               A `J` JSON request object.
     @return `True` if the message was successfully sent to the Notecard,
-      `False` if there was an error.
+            `False` if there was an error.
 */
 /**************************************************************************/
 bool Notecard::sendRequest(J *req)
@@ -353,13 +376,13 @@ void Notecard::logDebugf(const char *format, ...)
 
 /**************************************************************************/
 /*!
-    @brief  Periodically show Notecard sync status,
-      returning TRUE if something was displayed to the debug stream.
+    @brief  Periodically show Notecard sync status, returning `TRUE`
+            if something was displayed to the debug stream.
     @param    pollFrequencyMs
               The frequency to poll the Notecard for sync status.
-  @param    maxLevel
-        The maximum log level to output to the debug console. Pass
-        -1 for all.
+    @param    maxLevel
+              The maximum log level to output to the debug console. Pass
+              -1 for all.
     @return `True` if a pending response was displayed to the debug stream.
 */
 /**************************************************************************/

--- a/src/Notecard.h
+++ b/src/Notecard.h
@@ -28,6 +28,7 @@
 #include <stdint.h>
 
 #include "NoteLog.hpp"
+#include "NoteSerial.hpp"
 
 #ifdef ARDUINO
 #include <Arduino.h>
@@ -54,10 +55,15 @@ public:
     void begin(uint32_t i2cAddress = NOTE_I2C_ADDR_DEFAULT,
                uint32_t i2cMax = NOTE_I2C_MAX_DEFAULT,
                TwoWire &wirePort = Wire);
-    void begin(HardwareSerial &serial, int speed = 9600);
 #ifdef ARDUINO
-    void setDebugOutputStream(Stream &dbgserial);
+    inline void begin(HardwareSerial &serial, int speed = 9600) {
+        begin(reinterpret_cast<NoteSerial::channel_t>(&serial), speed);
+    }
+    inline void setDebugOutputStream(Stream &dbgserial) {
+        setDebugOutputStream(reinterpret_cast<NoteLog::channel_t>(&dgbserial));
+    }
 #endif
+    void begin(NoteSerial::channel_t serialChannel, int baudRate = 9600);
     void setDebugOutputStream(NoteLog::channel_t logChannel);
     void clearDebugOutputStream(void);
     J *newRequest(const char *request);
@@ -69,6 +75,9 @@ public:
     void logDebugf(const char *format, ...);
     bool debugSyncStatus(int pollFrequencyMs, int maxLevel);
     bool responseError(J *rsp);
+
+private:
+    void platformInit (bool assignCallbacks);
 };
 
 #endif

--- a/src/Notecard.h
+++ b/src/Notecard.h
@@ -68,7 +68,7 @@ public:
         begin(make_note_serial(&serial, speed));
     }
     inline void setDebugOutputStream(Stream &dbgserial) {
-        setDebugOutputStream(make_note_log(&dgbserial));
+        setDebugOutputStream(make_note_log(&dbgserial));
     }
 #endif
     void clearDebugOutputStream(void);

--- a/src/Notecard.h
+++ b/src/Notecard.h
@@ -27,6 +27,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "NoteI2c.hpp"
 #include "NoteLog.hpp"
 #include "NoteSerial.hpp"
 
@@ -52,19 +53,24 @@ class Notecard
 {
 public:
     ~Notecard(void);
-    void begin(uint32_t i2cAddress = NOTE_I2C_ADDR_DEFAULT,
-               uint32_t i2cMax = NOTE_I2C_MAX_DEFAULT,
-               TwoWire &wirePort = Wire);
+    void begin(NoteI2c * noteI2c,
+               uint32_t i2cAddress = NOTE_I2C_ADDR_DEFAULT,
+               uint32_t i2cMax = NOTE_I2C_MAX_DEFAULT);
+    void begin(NoteSerial * noteSerial);
+    void setDebugOutputStream(NoteLog * noteLog);
 #ifdef ARDUINO
-    inline void begin(HardwareSerial &serial, int speed = 9600) {
-        begin(reinterpret_cast<NoteSerial::channel_t>(&serial), speed);
+    inline void begin(uint32_t i2cAddress = NOTE_I2C_ADDR_DEFAULT,
+                      uint32_t i2cMax = NOTE_I2C_MAX_DEFAULT,
+                      TwoWire &wirePort = Wire) {
+        begin(make_note_i2c(&wirePort), i2cAddress, i2cMax);
+    }
+    inline void begin(HardwareSerial &serial, uint32_t speed = 9600) {
+        begin(make_note_serial(&serial, speed));
     }
     inline void setDebugOutputStream(Stream &dbgserial) {
-        setDebugOutputStream(reinterpret_cast<NoteLog::channel_t>(&dgbserial));
+        setDebugOutputStream(make_note_log(&dgbserial));
     }
 #endif
-    void begin(NoteSerial::channel_t serialChannel, int baudRate = 9600);
-    void setDebugOutputStream(NoteLog::channel_t logChannel);
     void clearDebugOutputStream(void);
     J *newRequest(const char *request);
     J *newCommand(const char *request);

--- a/src/Notecard.h
+++ b/src/Notecard.h
@@ -27,9 +27,14 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#ifndef NOTE_MOCK
+#include "NoteLog.hpp"
+
+#ifdef ARDUINO
 #include <Arduino.h>
 #include <Wire.h>
+#endif
+
+#ifndef NOTE_MOCK
 #include <note-c/note.h>
 #else
 #include "mock/mock-arduino.hpp"
@@ -50,7 +55,10 @@ public:
                uint32_t i2cMax = NOTE_I2C_MAX_DEFAULT,
                TwoWire &wirePort = Wire);
     void begin(HardwareSerial &serial, int speed = 9600);
+#ifdef ARDUINO
     void setDebugOutputStream(Stream &dbgserial);
+#endif
+    void setDebugOutputStream(NoteLog::channel_t logChannel);
     void clearDebugOutputStream(void);
     J *newRequest(const char *request);
     J *newCommand(const char *request);

--- a/src/sleepysignal.ino
+++ b/src/sleepysignal.ino
@@ -1,0 +1,58 @@
+#include <Notecard.h>
+
+#define serialDebug Serial
+
+Notecard notecard;
+
+void setup() {
+  serialDebug.begin(115200);
+  while (!serialDebug);
+  Serial1.begin(115200);
+
+  notecard.begin();
+  notecard.setDebugOutputStream(serialDebug);
+
+  {
+    J *req = notecard.newRequest("hub.set");
+    JAddStringToObject(req, "product", "com.email.you:project");
+    JAddStringToObject(req, "mode", "continuous");
+    JAddBoolToObject(req, "sync", true);
+    if (!notecard.sendRequest(req)) {
+      notecard.logDebug("hub.set failed\n");
+    }
+  }
+
+  notecard.logDebug("\nSetup complete\n");
+
+}
+
+void loop() {
+  {
+    J *req = notecard.newRequest("hub.signal");
+    J *resp = notecard.requestAndResponse(req);
+    J *body = JGetObject(resp, "body");
+    char *json_string = JConvertToJSONString(body);
+    JDelete(resp);
+    if (json_string) {
+      notecard.logDebugf("Signal: %s\n", json_string);
+      free(json_string);
+      // Dequeue all Signals as fast as possible
+      continue;
+    }
+  }
+  notecard.logDebug("No signal detected\n");
+
+  {
+    J *req = notecard.newRequest("card.attn");
+    JAddStringToObject(req, "mode", "arm,signal");
+    // This should NEVER return
+    if (!notecard.sendRequest(req)) {
+        //if resp.err == "" && !resp.Set then a signal has arrived
+        //continue
+    }
+  }
+
+  // Hardware error prevented sleeping
+  notecard.logDebug("card.attn failed\n");
+  delay(1000);
+}

--- a/test/NoteI2c_Arduino.test.cpp
+++ b/test/NoteI2c_Arduino.test.cpp
@@ -66,6 +66,7 @@ int test_make_note_i2c_enforces_singleton_by_returning_same_notei2c_object_for_a
   return result;
 }
 
+//int test_make_note_i2c_returns_nullptr_when_nullptr_is_passed_as_parameter()
 int test_make_note_i2c_deletes_singleton_when_nullptr_is_passed_as_parameter()
 {
   int result;

--- a/test/NoteLog_Arduino.test.cpp
+++ b/test/NoteLog_Arduino.test.cpp
@@ -66,6 +66,7 @@ int test_make_note_log_enforces_singleton_by_returning_same_notelog_object_for_a
     return result;
 }
 
+//int test_make_note_log_returns_nullptr_when_nullptr_is_passed_as_parameter()
 int test_make_note_log_deletes_singleton_when_nullptr_is_passed_as_parameter()
 {
     int result;

--- a/test/NoteSerial_Arduino.test.cpp
+++ b/test/NoteSerial_Arduino.test.cpp
@@ -66,6 +66,7 @@ int test_make_note_serial_enforces_singleton_by_returning_same_noteserial_object
     return result;
 }
 
+//int test_make_note_serial_returns_nullptr_when_nullptr_is_passed_as_parameter()
 int test_make_note_serial_deletes_singleton_when_nullptr_is_passed_as_parameter()
 {
     int result;

--- a/test/Notecard.test.cpp
+++ b/test/Notecard.test.cpp
@@ -3,16 +3,85 @@
 #include <cstring>
 #include <iostream>
 
-#include "Notecard.h"
-#include "NoteI2c_Arduino.hpp"
 #include "TestFunction.hpp"
-#include "mock/mock-arduino.hpp"
+
+#include "Notecard.h"
 #include "mock/mock-parameters.hpp"
 #include "mock/NoteI2c_Mock.hpp"
 #include "mock/NoteLog_Mock.hpp"
 #include "mock/NoteSerial_Mock.hpp"
 
 // Compile command: g++ -Wall -Wextra -Wpedantic mock/mock-arduino.cpp mock/mock-note-c-note.c mock/NoteI2c_Mock.cpp mock/NoteLog_Mock.cpp mock/NoteSerial_Mock.cpp ../src/Notecard.cpp Notecard.test.cpp -std=c++11 -I. -I../src -DNOTE_MOCK -o notecard.tests && ./notecard.tests || echo "Tests Result: $?"
+
+int test_notecard_begin_i2c_sets_user_agent_to_note_arduino()
+{
+  int result;
+
+   // Arrange
+  ////////////
+
+  const char * const EXPECTED_USER_AGENT = "note-arduino";
+  Notecard notecard;
+  NoteI2c_Mock mockI2c;
+
+  noteSetUserAgent_Parameters.reset();
+
+   // Action
+  ///////////
+
+  notecard.begin(&mockI2c);
+
+   // Assert
+  ///////////
+
+  if (noteSetUserAgent_Parameters.agent && !strcmp(EXPECTED_USER_AGENT, noteSetUserAgent_Parameters.agent))
+  {
+    result = 0;
+  }
+  else
+  {
+    result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\tnoteSetUserAgent_Parameters.agent == " << noteSetUserAgent_Parameters.agent_cache.c_str() << ", EXPECTED: " << EXPECTED_USER_AGENT << std::endl;
+    std::cout << "[";
+  }
+
+  return result;
+}
+
+int test_notecard_begin_i2c_sets_user_agent_to_note_arduino_when_interface_has_not_been_instantiated()
+{
+  int result;
+
+   // Arrange
+  ////////////
+
+  static const char * const EXPECTED_USER_AGENT = "note-arduino";
+  Notecard notecard;
+  noteSetUserAgent_Parameters.reset();
+
+   // Action
+  ///////////
+
+  notecard.begin(static_cast<NoteI2c *>(nullptr));
+
+   // Assert
+  ///////////
+
+  if (noteSetUserAgent_Parameters.agent && !strcmp(EXPECTED_USER_AGENT, noteSetUserAgent_Parameters.agent))
+  {
+    result = 0;
+  }
+  else
+  {
+    result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\tnoteSetUserAgent_Parameters.agent == " << noteSetUserAgent_Parameters.agent_cache.c_str() << ", EXPECTED: " << EXPECTED_USER_AGENT << std::endl;
+    std::cout << "[";
+  }
+
+  return result;
+}
 
 int test_notecard_begin_i2c_shares_a_memory_allocation_functon_pointer()
 {
@@ -22,13 +91,13 @@ int test_notecard_begin_i2c_shares_a_memory_allocation_functon_pointer()
   ////////////
 
   Notecard notecard;
-
+  NoteI2c_Mock mockI2c;
   noteSetFnDefault_Parameters.reset();
 
    // Action
   ///////////
 
-  notecard.begin(0x1B, 79);
+  notecard.begin(&mockI2c);
 
    // Assert
   ///////////
@@ -41,7 +110,40 @@ int test_notecard_begin_i2c_shares_a_memory_allocation_functon_pointer()
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
     std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
-    std::cout << "\tnoteSetFnDefault_Parameters.mallocfn == " << !!noteSetFnDefault_Parameters.mallocfn << ", EXPECTED: not 0 (`nullptr`)" << std::endl;
+    std::cout << "\tnoteSetFnDefault_Parameters.mallocfn == 0x" << std::hex << !!noteSetFnDefault_Parameters.mallocfn << ", EXPECTED: not 0 (`nullptr`)" << std::endl;
+    std::cout << "[";
+  }
+
+  return result;
+}
+
+int test_notecard_begin_i2c_sets_memory_allocation_functon_pointer_to_nullptr_when_interface_has_not_been_instantiated()
+{
+  int result;
+
+   // Arrange
+  ////////////
+
+  Notecard notecard;
+  noteSetFnDefault_Parameters.reset();
+
+   // Action
+  ///////////
+
+  notecard.begin(static_cast<NoteI2c *>(nullptr));
+
+   // Assert
+  ///////////
+
+  if (!noteSetFnDefault_Parameters.mallocfn)
+  {
+    result = 0;
+  }
+  else
+  {
+    result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\tnoteSetFnDefault_Parameters.mallocfn == 0x" << std::hex << noteSetFnDefault_Parameters.mallocfn << ", EXPECTED: 0 (`nullptr`)" << std::endl;
     std::cout << "[";
   }
 
@@ -56,13 +158,13 @@ int test_notecard_begin_i2c_shares_a_memory_free_functon_pointer()
   ////////////
 
   Notecard notecard;
-
+  NoteI2c_Mock mockI2c;
   noteSetFnDefault_Parameters.reset();
 
    // Action
   ///////////
 
-  notecard.begin(0x1B, 79);
+  notecard.begin(&mockI2c);
 
    // Assert
   ///////////
@@ -75,7 +177,40 @@ int test_notecard_begin_i2c_shares_a_memory_free_functon_pointer()
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
     std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
-    std::cout << "\tnoteSetFnDefault_Parameters.freefn == " << !!noteSetFnDefault_Parameters.freefn << ", EXPECTED: not 0 (`nullptr`)" << std::endl;
+    std::cout << "\tnoteSetFnDefault_Parameters.freefn == 0x" << std::hex << !!noteSetFnDefault_Parameters.freefn << ", EXPECTED: not 0 (`nullptr`)" << std::endl;
+    std::cout << "[";
+  }
+
+  return result;
+}
+
+int test_notecard_begin_i2c_sets_memory_free_functon_pointer_to_nullptr_when_interface_has_not_been_instantiated()
+{
+  int result;
+
+   // Arrange
+  ////////////
+
+  Notecard notecard;
+  noteSetFnDefault_Parameters.reset();
+
+   // Action
+  ///////////
+
+  notecard.begin(static_cast<NoteI2c *>(nullptr));
+
+   // Assert
+  ///////////
+
+  if (!noteSetFnDefault_Parameters.freefn)
+  {
+    result = 0;
+  }
+  else
+  {
+    result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\tnoteSetFnDefault_Parameters.freefn == 0x" << std::hex << noteSetFnDefault_Parameters.freefn << ", EXPECTED: 0 (`nullptr`)" << std::endl;
     std::cout << "[";
   }
 
@@ -90,13 +225,13 @@ int test_notecard_begin_i2c_shares_a_delay_functon_pointer()
   ////////////
 
   Notecard notecard;
-
+  NoteI2c_Mock mockI2c;
   noteSetFnDefault_Parameters.reset();
 
    // Action
   ///////////
 
-  notecard.begin(0x1B, 79);
+  notecard.begin(&mockI2c);
 
    // Arrange
   ////////////
@@ -109,7 +244,40 @@ int test_notecard_begin_i2c_shares_a_delay_functon_pointer()
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
     std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
-    std::cout << "\tnoteSetFnDefault_Parameters.delayfn == " << !!noteSetFnDefault_Parameters.delayfn << ", EXPECTED: not 0 (`nullptr`)" << std::endl;
+    std::cout << "\tnoteSetFnDefault_Parameters.delayfn == 0x" << std::hex << !!noteSetFnDefault_Parameters.delayfn << ", EXPECTED: not 0 (`nullptr`)" << std::endl;
+    std::cout << "[";
+  }
+
+  return result;
+}
+
+int test_notecard_begin_i2c_sets_delay_functon_pointer_to_nullptr_when_interface_has_not_been_instantiated()
+{
+  int result;
+
+   // Arrange
+  ////////////
+
+  Notecard notecard;
+  noteSetFnDefault_Parameters.reset();
+
+   // Action
+  ///////////
+
+  notecard.begin(static_cast<NoteI2c *>(nullptr));
+
+   // Arrange
+  ////////////
+
+  if (!noteSetFnDefault_Parameters.delayfn)
+  {
+    result = 0;
+  }
+  else
+  {
+    result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\tnoteSetFnDefault_Parameters.delayfn == 0x" << std::hex << noteSetFnDefault_Parameters.delayfn << ", EXPECTED: 0 (`nullptr`)" << std::endl;
     std::cout << "[";
   }
 
@@ -124,13 +292,13 @@ int test_notecard_begin_i2c_shares_a_millis_functon_pointer()
   ////////////
 
   Notecard notecard;
-
+  NoteI2c_Mock mockI2c;
   noteSetFnDefault_Parameters.reset();
 
    // Action
   ///////////
 
-  notecard.begin(0x1B, 79);
+  notecard.begin(&mockI2c);
 
    // Assert
   ///////////
@@ -143,7 +311,40 @@ int test_notecard_begin_i2c_shares_a_millis_functon_pointer()
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
     std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
-    std::cout << "\tnoteSetFnDefault_Parameters.millisfn == " << !!noteSetFnDefault_Parameters.millisfn << ", EXPECTED: not 0 (`nullptr`)" << std::endl;
+    std::cout << "\tnoteSetFnDefault_Parameters.millisfn == 0x" << std::hex << !!noteSetFnDefault_Parameters.millisfn << ", EXPECTED: not 0 (`nullptr`)" << std::endl;
+    std::cout << "[";
+  }
+
+  return result;
+}
+
+int test_notecard_begin_i2c_sets_millis_functon_pointer_to_nullptr_when_interface_has_not_been_instantiated()
+{
+  int result;
+
+   // Arrange
+  ////////////
+
+  Notecard notecard;
+  noteSetFnDefault_Parameters.reset();
+
+   // Action
+  ///////////
+
+  notecard.begin(static_cast<NoteI2c *>(nullptr));
+
+   // Assert
+  ///////////
+
+  if (!noteSetFnDefault_Parameters.millisfn)
+  {
+    result = 0;
+  }
+  else
+  {
+    result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\tnoteSetFnDefault_Parameters.millisfn == 0x" << std::hex << noteSetFnDefault_Parameters.millisfn << ", EXPECTED: 0 (`nullptr`)" << std::endl;
     std::cout << "[";
   }
 
@@ -157,16 +358,17 @@ int test_notecard_begin_i2c_does_not_modify_i2c_address_parameter_before_passing
    // Arrange
   ////////////
 
-  Notecard notecard;
   // 0x1B binary representation => 0001 1011
   const uint16_t EXPECTED_ADDRESS = 0x1B;
 
+  Notecard notecard;
+  NoteI2c_Mock mockI2c;
   noteSetFnI2C_Parameters.reset();
 
    // Action
   ///////////
 
-  notecard.begin(EXPECTED_ADDRESS, 79);
+  notecard.begin(&mockI2c, EXPECTED_ADDRESS);
 
    // Assert
   ///////////
@@ -179,7 +381,43 @@ int test_notecard_begin_i2c_does_not_modify_i2c_address_parameter_before_passing
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
     std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
-    std::cout << "\tnoteSetFnI2C_Parameters.i2caddr == " << noteSetFnI2C_Parameters.i2caddr << ", EXPECTED: " << EXPECTED_ADDRESS << std::endl;
+    std::cout << "\tnoteSetFnI2C_Parameters.i2caddr == 0x" << std::hex << noteSetFnI2C_Parameters.i2caddr << ", EXPECTED: " << EXPECTED_ADDRESS << std::endl;
+    std::cout << "[";
+  }
+
+  return result;
+}
+
+int test_notecard_begin_i2c_sets_i2c_address_parameter_to_zero_before_passing_to_note_c_when_interface_has_not_been_instantiated()
+{
+  int result;
+
+   // Arrange
+  ////////////
+
+  // 0x1B binary representation => 0001 1011
+  const uint16_t SUPPLIED_ADDRESS = 0x1B;
+
+  Notecard notecard;
+  noteSetFnI2C_Parameters.reset();
+
+   // Action
+  ///////////
+
+  notecard.begin(static_cast<NoteI2c *>(nullptr), SUPPLIED_ADDRESS);
+
+   // Assert
+  ///////////
+
+  if (!noteSetFnI2C_Parameters.i2caddr)
+  {
+    result = 0;
+  }
+  else
+  {
+    result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\tnoteSetFnI2C_Parameters.i2caddr == 0x" << std::hex << noteSetFnI2C_Parameters.i2caddr << ", EXPECTED: 0x00" << std::endl;
     std::cout << "[";
   }
 
@@ -193,15 +431,16 @@ int test_notecard_begin_i2c_does_not_modify_i2c_max_parameter_before_passing_to_
    // Arrange
   ////////////
 
-  Notecard notecard;
   const uint32_t EXPECTED_RESULT = 79;
 
+  Notecard notecard;
+  NoteI2c_Mock mockI2c;
   noteSetFnI2C_Parameters.reset();
 
    // Action
   ///////////
 
-  notecard.begin(0x1B, EXPECTED_RESULT);
+  notecard.begin(&mockI2c, 0x1B, EXPECTED_RESULT);
 
    // Assert
   ///////////
@@ -221,6 +460,41 @@ int test_notecard_begin_i2c_does_not_modify_i2c_max_parameter_before_passing_to_
   return result;
 }
 
+int test_notecard_begin_i2c_sets_i2c_max_parameter_to_zero_before_passing_to_note_c_when_interface_has_not_been_instantiated()
+{
+  int result;
+
+   // Arrange
+  ////////////
+
+  const uint32_t SUPPLIED_VALUE = 79;
+
+  Notecard notecard;
+  noteSetFnI2C_Parameters.reset();
+
+   // Action
+  ///////////
+
+  notecard.begin(static_cast<NoteI2c *>(nullptr), 0x1B, SUPPLIED_VALUE);
+
+   // Assert
+  ///////////
+
+  if (!noteSetFnI2C_Parameters.i2cmax)
+  {
+    result = 0;
+  }
+  else
+  {
+    result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\tnoteSetFnI2C_Parameters.i2cmax == " << noteSetFnI2C_Parameters.i2cmax << ", EXPECTED: 0" << std::endl;
+    std::cout << "[";
+  }
+
+  return result;
+}
+
 int test_notecard_begin_i2c_shares_an_i2c_reset_functon_pointer()
 {
   int result;
@@ -229,13 +503,13 @@ int test_notecard_begin_i2c_shares_an_i2c_reset_functon_pointer()
   ////////////
 
   Notecard notecard;
-
+  NoteI2c_Mock mockI2c;
   noteSetFnI2C_Parameters.reset();
 
    // Action
   ///////////
 
-  notecard.begin(0x1B, 79);
+  notecard.begin(&mockI2c);
 
    // Assert
   ///////////
@@ -248,7 +522,40 @@ int test_notecard_begin_i2c_shares_an_i2c_reset_functon_pointer()
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
     std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
-    std::cout << "\tnoteSetFnI2C_Parameters.resetfn == " << !!noteSetFnI2C_Parameters.resetfn << ", EXPECTED: not 0 (`nullptr`)" << std::endl;
+    std::cout << "\tnoteSetFnI2C_Parameters.resetfn == 0x" << std::hex << !!noteSetFnI2C_Parameters.resetfn << ", EXPECTED: not 0x0 (`nullptr`)" << std::endl;
+    std::cout << "[";
+  }
+
+  return result;
+}
+
+int test_notecard_begin_i2c_sets_i2c_reset_functon_pointer_to_nullptr_when_interface_has_not_been_instantiated()
+{
+  int result;
+
+   // Arrange
+  ////////////
+
+  Notecard notecard;
+  noteSetFnI2C_Parameters.reset();
+
+   // Action
+  ///////////
+
+  notecard.begin(static_cast<NoteI2c *>(nullptr));
+
+   // Assert
+  ///////////
+
+  if (!noteSetFnI2C_Parameters.resetfn)
+  {
+    result = 0;
+  }
+  else
+  {
+    result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\tnoteSetFnI2C_Parameters.resetfn == 0x" << std::hex << noteSetFnI2C_Parameters.resetfn << ", EXPECTED: 0x0 (`nullptr`)" << std::endl;
     std::cout << "[";
   }
 
@@ -263,13 +570,13 @@ int test_notecard_begin_i2c_shares_an_i2c_transmit_functon_pointer()
   ////////////
 
   Notecard notecard;
-
+  NoteI2c_Mock mockI2c;
   noteSetFnI2C_Parameters.reset();
 
    // Action
   ///////////
 
-  notecard.begin(0x1B, 79);
+  notecard.begin(&mockI2c);
 
    // Assert
   ///////////
@@ -282,7 +589,40 @@ int test_notecard_begin_i2c_shares_an_i2c_transmit_functon_pointer()
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
     std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
-    std::cout << "\tnoteSetFnI2C_Parameters.transmitfn == " << !!noteSetFnI2C_Parameters.transmitfn << ", EXPECTED: not 0 (`nullptr`)" << std::endl;
+    std::cout << "\tnoteSetFnI2C_Parameters.transmitfn == 0x" << std::hex << !!noteSetFnI2C_Parameters.transmitfn << ", EXPECTED: not 0x0 (`nullptr`)" << std::endl;
+    std::cout << "[";
+  }
+
+  return result;
+}
+
+int test_notecard_begin_i2c_sets_i2c_transmit_functon_pointer_to_nullptr_when_interface_has_not_been_instantiated()
+{
+  int result;
+
+   // Arrange
+  ////////////
+
+  Notecard notecard;
+  noteSetFnI2C_Parameters.reset();
+
+   // Action
+  ///////////
+
+  notecard.begin(static_cast<NoteI2c *>(nullptr));
+
+   // Assert
+  ///////////
+
+  if (!noteSetFnI2C_Parameters.transmitfn)
+  {
+    result = 0;
+  }
+  else
+  {
+    result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\tnoteSetFnI2C_Parameters.transmitfn == 0x" << std::hex << noteSetFnI2C_Parameters.transmitfn << ", EXPECTED: 0x0 (`nullptr`)" << std::endl;
     std::cout << "[";
   }
 
@@ -297,13 +637,13 @@ int test_notecard_begin_i2c_shares_an_i2c_receive_functon_pointer()
   ////////////
 
   Notecard notecard;
-
+  NoteI2c_Mock mockI2c;
   noteSetFnI2C_Parameters.reset();
 
    // Action
   ///////////
 
-  notecard.begin(0x1B, 79);
+  notecard.begin(&mockI2c);
 
    // Assert
   ///////////
@@ -316,14 +656,14 @@ int test_notecard_begin_i2c_shares_an_i2c_receive_functon_pointer()
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
     std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
-    std::cout << "\tnoteSetFnI2C_Parameters.receivefn == " << !!noteSetFnI2C_Parameters.receivefn << ", EXPECTED: not 0 (`nullptr`)" << std::endl;
+    std::cout << "\tnoteSetFnI2C_Parameters.receivefn == 0x" << std::hex << !!noteSetFnI2C_Parameters.receivefn << ", EXPECTED: not 0x0 (`nullptr`)" << std::endl;
     std::cout << "[";
   }
 
   return result;
 }
 
-int test_notecard_begin_i2c_default_parameter_for_i2c_max_is_passed_to_note_c()
+int test_notecard_begin_i2c_sets_i2c_receive_functon_pointer_to_nullptr_when_interface_has_not_been_instantiated()
 {
   int result;
 
@@ -331,14 +671,47 @@ int test_notecard_begin_i2c_default_parameter_for_i2c_max_is_passed_to_note_c()
   ////////////
 
   Notecard notecard;
+  noteSetFnI2C_Parameters.reset();
 
+   // Action
+  ///////////
+
+  notecard.begin(static_cast<NoteI2c *>(nullptr));
+
+   // Assert
+  ///////////
+
+  if (!noteSetFnI2C_Parameters.receivefn)
+  {
+    result = 0;
+  }
+  else
+  {
+    result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\tnoteSetFnI2C_Parameters.receivefn == 0x" << std::hex << noteSetFnI2C_Parameters.receivefn << ", EXPECTED: 0x0 (`nullptr`)" << std::endl;
+    std::cout << "[";
+  }
+
+  return result;
+}
+
+int test_notecard_begin_i2c_default_parameter_for_i2cMax_is_passed_to_note_c()
+{
+  int result;
+
+   // Arrange
+  ////////////
+
+  Notecard notecard;
+  NoteI2c_Mock mockI2c;
   noteSetFnI2C_Parameters.reset();
   noteSetFnI2C_Parameters.i2cmax = (NOTE_I2C_MAX_DEFAULT - 1);
 
    // Action
   ///////////
 
-  notecard.begin(0x1B);
+  notecard.begin(&mockI2c, 0x1B);
 
    // Assert
   ///////////
@@ -358,7 +731,7 @@ int test_notecard_begin_i2c_default_parameter_for_i2c_max_is_passed_to_note_c()
   return result;
 }
 
-int test_notecard_begin_i2c_default_parameter_for_i2c_address_is_passed_to_note_c()
+int test_notecard_begin_i2c_default_parameter_for_i2cAddress_is_passed_to_note_c()
 {
   int result;
 
@@ -366,14 +739,14 @@ int test_notecard_begin_i2c_default_parameter_for_i2c_address_is_passed_to_note_
   ////////////
 
   Notecard notecard;
-
+  NoteI2c_Mock mockI2c;
   noteSetFnI2C_Parameters.reset();
   noteSetFnI2C_Parameters.i2caddr = (NOTE_I2C_ADDR_DEFAULT - 1);
 
    // Action
   ///////////
 
-  notecard.begin();
+  notecard.begin(&mockI2c);
 
    // Assert
   ///////////
@@ -386,111 +759,7 @@ int test_notecard_begin_i2c_default_parameter_for_i2c_address_is_passed_to_note_
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
     std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
-    std::cout << "\tnoteSetFnI2C_Parameters.i2caddr == " << noteSetFnI2C_Parameters.i2caddr << ", EXPECTED: " << NOTE_I2C_ADDR_DEFAULT << std::endl;
-    std::cout << "[";
-  }
-
-  return result;
-}
-
-int test_notecard_begin_i2c_default_parameter_for_wirePort_instantiates_the_note_i2c_interface_with_wire()
-{
-  int result;
-
-   // Arrange
-  ////////////
-
-  Notecard notecard;
-
-  make_note_i2c_Parameters.reset();
-
-   // Action
-  ///////////
-
-  notecard.begin();
-
-   // Assert
-  ///////////
-
-  if (&Wire == make_note_i2c_Parameters.i2c_bus)
-  {
-    result = 0;
-  }
-  else
-  {
-    result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
-    std::cout << "\tmake_note_i2c_Parameters.i2c_bus == " << !!make_note_i2c_Parameters.i2c_bus << ", EXPECTED: " << &Wire << std::endl;
-    std::cout << "[";
-  }
-
-  return result;
-}
-
-int test_notecard_begin_i2c_parameter_for_wirePort_instantiates_the_note_i2c_interface_with_wirePort()
-{
-  int result;
-
-   // Arrange
-  ////////////
-
-  Notecard notecard;
-  TwoWire mockWire;
-
-  make_note_i2c_Parameters.reset();
-
-   // Action
-  ///////////
-
-  notecard.begin(NOTE_I2C_ADDR_DEFAULT, NOTE_I2C_MAX_DEFAULT, mockWire);
-
-   // Assert
-  ///////////
-
-  if (&mockWire == make_note_i2c_Parameters.i2c_bus)
-  {
-    result = 0;
-  }
-  else
-  {
-    result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
-    std::cout << "\tmake_note_i2c_Parameters.i2c_bus == " << make_note_i2c_Parameters.i2c_bus << ", EXPECTED: " << &mockWire << std::endl;
-    std::cout << "[";
-  }
-
-  return result;
-}
-
-int test_notecard_begin_i2c_sets_user_agent_to_note_arduino()
-{
-  int result;
-
-   // Arrange
-  ////////////
-
-  const char * const EXPECTED_USER_AGENT = "note-arduino";
-  Notecard notecard;
-
-  noteSetUserAgent_Parameters.reset();
-
-   // Action
-  ///////////
-
-  notecard.begin();
-
-   // Assert
-  ///////////
-
-  if (noteSetUserAgent_Parameters.agent && !strcmp(EXPECTED_USER_AGENT, noteSetUserAgent_Parameters.agent))
-  {
-    result = 0;
-  }
-  else
-  {
-    result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
-    std::cout << "\tnoteSetUserAgent_Parameters.agent == " << noteSetUserAgent_Parameters.agent << ", EXPECTED: " << EXPECTED_USER_AGENT << std::endl;
+    std::cout << "\tnoteSetFnI2C_Parameters.i2caddr == 0x" << std::hex << noteSetFnI2C_Parameters.i2caddr << ", EXPECTED: 0x" << std::hex << NOTE_I2C_ADDR_DEFAULT << std::endl;
     std::cout << "[";
   }
 
@@ -504,18 +773,15 @@ int test_notecard_begin_serial_sets_user_agent_to_note_arduino()
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   static const char * const EXPECTED_USER_AGENT = "note-arduino";
   Notecard notecard;
   NoteSerial_Mock mockSerial;  // Instantiate NoteSerial (mocked)
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = &mockSerial;  // Return mocked interface
   noteSetUserAgent_Parameters.reset();
 
    // Action
   ///////////
 
-  notecard.begin(MOCK_SERIAL_CHANNEL);
+  notecard.begin(&mockSerial);
 
    // Assert
   ///////////
@@ -528,7 +794,7 @@ int test_notecard_begin_serial_sets_user_agent_to_note_arduino()
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
     std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
-    std::cout << "\tnoteSetUserAgent_Parameters.agent == " << noteSetUserAgent_Parameters.agent << ", EXPECTED: " << EXPECTED_USER_AGENT << std::endl;
+    std::cout << "\tnoteSetUserAgent_Parameters.agent == " << noteSetUserAgent_Parameters.agent_cache.c_str() << ", EXPECTED: " << EXPECTED_USER_AGENT << std::endl;
     std::cout << "[";
   }
 
@@ -542,17 +808,14 @@ int test_notecard_begin_serial_sets_user_agent_to_note_arduino_when_interface_ha
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   static const char * const EXPECTED_USER_AGENT = "note-arduino";
   Notecard notecard;
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = nullptr;  // Ensure interface is not instantiated
   noteSetUserAgent_Parameters.reset();
 
    // Action
   ///////////
 
-  notecard.begin(MOCK_SERIAL_CHANNEL);
+  notecard.begin(static_cast<NoteSerial *>(nullptr));
 
    // Assert
   ///////////
@@ -565,7 +828,7 @@ int test_notecard_begin_serial_sets_user_agent_to_note_arduino_when_interface_ha
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
     std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
-    std::cout << "\tnoteSetUserAgent_Parameters.agent == " << noteSetUserAgent_Parameters.agent << ", EXPECTED: " << EXPECTED_USER_AGENT << std::endl;
+    std::cout << "\tnoteSetUserAgent_Parameters.agent == " << noteSetUserAgent_Parameters.agent_cache.c_str() << ", EXPECTED: " << EXPECTED_USER_AGENT << std::endl;
     std::cout << "[";
   }
 
@@ -579,17 +842,14 @@ int test_notecard_begin_serial_shares_a_memory_allocation_functon_pointer()
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   Notecard notecard;
   NoteSerial_Mock mockSerial;  // Instantiate NoteSerial (mocked)
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = &mockSerial;  // Return mocked interface
   noteSetFnDefault_Parameters.reset();
 
    // Action
   ///////////
 
-  notecard.begin(MOCK_SERIAL_CHANNEL, 9600);
+  notecard.begin(&mockSerial);
 
    // Assert
   ///////////
@@ -617,14 +877,12 @@ int test_notecard_begin_serial_sets_memory_allocation_functon_pointer_to_nullptr
   ////////////
 
   Notecard notecard;
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = nullptr;  // Ensure interface is not instantiated
   noteSetFnDefault_Parameters.reset();
 
    // Action
   ///////////
 
-  notecard.begin(nullptr);
+  notecard.begin(static_cast<NoteSerial *>(nullptr));
 
    // Assert
   ///////////
@@ -651,17 +909,14 @@ int test_notecard_begin_serial_shares_a_memory_free_functon_pointer()
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   Notecard notecard;
   NoteSerial_Mock mockSerial;  // Instantiate NoteSerial (mocked)
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = &mockSerial;  // Return mocked interface
   noteSetFnDefault_Parameters.reset();
 
    // Action
   ///////////
 
-  notecard.begin(MOCK_SERIAL_CHANNEL, 9600);
+  notecard.begin(&mockSerial);
 
    // Assert
   ///////////
@@ -689,14 +944,12 @@ int test_notecard_begin_serial_sets_memory_free_functon_pointer_to_nullptr_when_
   ////////////
 
   Notecard notecard;
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = nullptr;  // Ensure interface is not instantiated
   noteSetFnDefault_Parameters.reset();
 
    // Action
   ///////////
 
-  notecard.begin(nullptr, 9600);
+  notecard.begin(static_cast<NoteSerial *>(nullptr));
 
    // Assert
   ///////////
@@ -723,17 +976,14 @@ int test_notecard_begin_serial_shares_a_delay_functon_pointer()
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   Notecard notecard;
   NoteSerial_Mock mockSerial;  // Instantiate NoteSerial (mocked)
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = &mockSerial;  // Return mocked interface
   noteSetFnDefault_Parameters.reset();
 
    // Action
   ///////////
 
-  notecard.begin(MOCK_SERIAL_CHANNEL, 9600);
+  notecard.begin(&mockSerial);
 
    // Assert
   ///////////
@@ -761,14 +1011,12 @@ int test_notecard_begin_serial_sets_delay_functon_pointer_to_nullptr_when_interf
   ////////////
 
   Notecard notecard;
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = nullptr;  // Ensure interface is not instantiated
   noteSetFnDefault_Parameters.reset();
 
    // Action
   ///////////
 
-  notecard.begin(nullptr, 9600);
+  notecard.begin(static_cast<NoteSerial *>(nullptr));
 
    // Assert
   ///////////
@@ -795,17 +1043,14 @@ int test_notecard_begin_serial_shares_a_millis_functon_pointer()
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   Notecard notecard;
   NoteSerial_Mock mockSerial;  // Instantiate NoteSerial (mocked)
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = &mockSerial;  // Return mocked interface
   noteSetFnDefault_Parameters.reset();
 
    // Action
   ///////////
 
-  notecard.begin(MOCK_SERIAL_CHANNEL, 9600);
+  notecard.begin(&mockSerial);
 
    // Assert
   ///////////
@@ -833,14 +1078,12 @@ int test_notecard_begin_serial_sets_millis_functon_pointer_to_nullptr_when_inter
   ////////////
 
   Notecard notecard;
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = nullptr;  // Ensure interface is not instantiated
   noteSetFnDefault_Parameters.reset();
 
    // Action
   ///////////
 
-  notecard.begin(nullptr, 9600);
+  notecard.begin(static_cast<NoteSerial *>(nullptr));
 
    // Assert
   ///////////
@@ -867,17 +1110,14 @@ int test_notecard_begin_serial_shares_a_serial_reset_functon_pointer()
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   Notecard notecard;
   NoteSerial_Mock mockSerial;  // Instantiate NoteSerial (mocked)
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = &mockSerial;  // Return mocked interface
   noteSetFnDefault_Parameters.reset();
 
    // Action
   ///////////
 
-  notecard.begin(MOCK_SERIAL_CHANNEL, 9600);
+  notecard.begin(&mockSerial);
 
    // Assert
   ///////////
@@ -905,14 +1145,12 @@ int test_notecard_begin_serial_sets_serial_reset_functon_pointer_to_nullptr_when
   ////////////
 
   Notecard notecard;
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = nullptr;  // Ensure interface is not instantiated
   noteSetFnSerial_Parameters.reset();
 
    // Action
   ///////////
 
-  notecard.begin(nullptr, 9600);
+  notecard.begin(static_cast<NoteSerial *>(nullptr));
 
    // Assert
   ///////////
@@ -939,17 +1177,14 @@ int test_notecard_begin_serial_shares_a_serial_transmit_functon_pointer()
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   Notecard notecard;
   NoteSerial_Mock mockSerial;  // Instantiate NoteSerial (mocked)
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = &mockSerial;  // Return mocked interface
   noteSetFnDefault_Parameters.reset();
 
    // Action
   ///////////
 
-  notecard.begin(MOCK_SERIAL_CHANNEL, 9600);
+  notecard.begin(&mockSerial);
 
    // Assert
   ///////////
@@ -977,14 +1212,12 @@ int test_notecard_begin_serial_sets_transmit_functon_pointer_to_nullptr_when_int
   ////////////
 
   Notecard notecard;
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = nullptr;  // Ensure interface is not instantiated
   noteSetFnDefault_Parameters.reset();
 
    // Action
   ///////////
 
-  notecard.begin(nullptr, 9600);
+  notecard.begin(static_cast<NoteSerial *>(nullptr));
 
    // Assert
   ///////////
@@ -1011,17 +1244,14 @@ int test_notecard_begin_serial_shares_a_serial_available_functon_pointer()
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   Notecard notecard;
   NoteSerial_Mock mockSerial;  // Instantiate NoteSerial (mocked)
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = &mockSerial;  // Return mocked interface
   noteSetFnDefault_Parameters.reset();
 
    // Action
   ///////////
 
-  notecard.begin(MOCK_SERIAL_CHANNEL, 9600);
+  notecard.begin(&mockSerial);
 
    // Assert
   ///////////
@@ -1049,14 +1279,12 @@ int test_notecard_begin_serial_sets_serial_available_functon_pointer_to_nullptr_
   ////////////
 
   Notecard notecard;
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = nullptr;  // Ensure interface is not instantiated
   noteSetFnDefault_Parameters.reset();
 
    // Action
   ///////////
 
-  notecard.begin(nullptr, 9600);
+  notecard.begin(static_cast<NoteSerial *>(nullptr));
 
    // Assert
   ///////////
@@ -1083,17 +1311,14 @@ int test_notecard_begin_serial_shares_a_serial_receive_functon_pointer()
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   Notecard notecard;
   NoteSerial_Mock mockSerial;  // Instantiate NoteSerial (mocked)
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = &mockSerial;  // Return mocked interface
   noteSetFnDefault_Parameters.reset();
 
    // Action
   ///////////
 
-  notecard.begin(MOCK_SERIAL_CHANNEL, 9600);
+  notecard.begin(&mockSerial);
 
    // Assert
   ///////////
@@ -1121,14 +1346,12 @@ int test_notecard_begin_serial_sets_serial_receive_functon_pointer_to_nullptr_wh
   ////////////
 
   Notecard notecard;
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = nullptr;  // Ensure interface is not instantiated
   noteSetFnDefault_Parameters.reset();
 
    // Action
   ///////////
 
-  notecard.begin(nullptr, 9600);
+  notecard.begin(static_cast<NoteSerial *>(nullptr));
 
    // Assert
   ///////////
@@ -1148,113 +1371,6 @@ int test_notecard_begin_serial_sets_serial_receive_functon_pointer_to_nullptr_wh
   return result;
 }
 
-int test_notecard_begin_serial_initializes_the_provided_serial_interface_with_provided_speed()
-{
-  int result;
-
-   // Arrange
-  ////////////
-
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
-  static const unsigned int EXPECTED_BAUD_RATE = 9600;
-  Notecard notecard;
-
-  make_note_serial_Parameters.reset();
-
-   // Action
-  ///////////
-
-  notecard.begin(MOCK_SERIAL_CHANNEL, EXPECTED_BAUD_RATE);
-
-   // Assert
-  ///////////
-
-  if (EXPECTED_BAUD_RATE == make_note_serial_Parameters.baud_rate)
-  {
-    result = 0;
-  }
-  else
-  {
-    result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
-    std::cout << "\tmake_note_serial_Parameters.baud_rate == " << make_note_serial_Parameters.baud_rate << ", EXPECTED: " << EXPECTED_BAUD_RATE << std::endl;
-    std::cout << "[";
-  }
-
-  return result;
-}
-
-int test_notecard_begin_serial_initializes_the_provided_serial_interface_with_default_speed()
-{
-  int result;
-
-   // Arrange
-  ////////////
-
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
-  static const unsigned int EXPECTED_BAUD_RATE = 9600;
-  Notecard notecard;
-
-  make_note_serial_Parameters.reset();
-
-   // Action
-  ///////////
-
-  notecard.begin(MOCK_SERIAL_CHANNEL);
-
-   // Assert
-  ///////////
-
-  if (EXPECTED_BAUD_RATE == make_note_serial_Parameters.baud_rate)
-  {
-    result = 0;
-  }
-  else
-  {
-    result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
-    std::cout << "\tmake_note_serial_Parameters.baud_rate == " << make_note_serial_Parameters.baud_rate << ", EXPECTED: " << EXPECTED_BAUD_RATE << std::endl;
-    std::cout << "[";
-  }
-
-  return result;
-}
-
-int test_notecard_setDebugOutputStream_does_not_modify_log_channel_parameter_before_passing_to_make_note_log()
-{
-  int result;
-
-   // Arrange
-  ////////////
-
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
-  Notecard notecard;
-
-  make_note_log_Parameters.reset();
-
-   // Action
-  ///////////
-
-  notecard.setDebugOutputStream(MOCK_SERIAL_CHANNEL);
-
-   // Assert
-  ///////////
-
-  if (MOCK_SERIAL_CHANNEL == make_note_log_Parameters.log_channel)
-  {
-    result = 0;
-  }
-  else
-  {
-    result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
-    std::cout << "\tmake_note_log_Parameters.log_channel == " << make_note_log_Parameters.log_channel << ", EXPECTED: " << &Serial << std::endl;
-    std::cout << "[";
-  }
-
-  return result;
-}
-
 int test_notecard_setDebugOutputStream_shares_a_debug_log_functon_pointer()
 {
   int result;
@@ -1262,18 +1378,14 @@ int test_notecard_setDebugOutputStream_shares_a_debug_log_functon_pointer()
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   Notecard notecard;
   NoteLog_Mock mockLog;
-
-  make_note_log_Parameters.reset();
-  make_note_log_Parameters.result = &mockLog;
   noteSetFnDebugOutput_Parameters.reset();
 
    // Action
   ///////////
 
-  notecard.setDebugOutputStream(MOCK_SERIAL_CHANNEL);
+  notecard.setDebugOutputStream(&mockLog);
 
    // Assert
   ///////////
@@ -1301,8 +1413,6 @@ int test_notecard_setDebugOutputStream_clears_the_debug_log_functon_pointer_when
   ////////////
 
   Notecard notecard;
-
-  make_note_log_Parameters.reset();
   noteSetFnDebugOutput_Parameters.reset();
   noteSetFnDebugOutput_Parameters.fn = reinterpret_cast<debugOutputFn>(&result);
 
@@ -1997,16 +2107,15 @@ int test_static_callback_note_i2c_receive_invokes_notei2c_receive()
   uint32_t actual_response_size;
 
   Notecard notecard;
-  NoteI2c_Arduino mockI2c_arduino(Wire);  // Instantiate NoteI2c (mocked)
-  make_note_i2c_Parameters.reset();
-  make_note_i2c_Parameters.result = &mockI2c_arduino;  // Return mocked interface
-  notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
+  NoteI2c_Mock mockI2c;  // Instantiate NoteI2c (mocked)
+  notecard.begin(&mockI2c);  // Provides access to the hidden static callback methods through `note-c` mocks
+  i2cReceiveFn noteI2cReceive = noteSetFnI2C_Parameters.receivefn;
   noteI2cReceive_Parameters.reset();  // Clear the structure for testing results
 
    // Action
   ///////////
 
-  noteSetFnI2C_Parameters.receivefn(ADDRESS, response_buffer, SIZE, &actual_response_size);
+  noteI2cReceive(ADDRESS, response_buffer, SIZE, &actual_response_size);
 
    // Assert
   ///////////
@@ -2040,16 +2149,15 @@ int test_static_callback_note_i2c_receive_does_not_modify_device_address_paramet
   uint32_t actual_response_size;
 
   Notecard notecard;
-  NoteI2c_Arduino mockI2c_arduino(Wire);  // Instantiate NoteI2c (mocked)
-  make_note_i2c_Parameters.reset();
-  make_note_i2c_Parameters.result = &mockI2c_arduino;  // Return mocked interface
-  notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
+  NoteI2c_Mock mockI2c;  // Instantiate NoteI2c (mocked)
+  notecard.begin(&mockI2c);  // Provides access to the hidden static callback methods through `note-c` mocks
+  i2cReceiveFn noteI2cReceive = noteSetFnI2C_Parameters.receivefn;
   noteI2cReceive_Parameters.reset();  // Clear the structure for testing results
 
    // Action
   ///////////
 
-  noteSetFnI2C_Parameters.receivefn(EXPECTED_ADDRESS, response_buffer, SIZE, &actual_response_size);
+  noteI2cReceive(EXPECTED_ADDRESS, response_buffer, SIZE, &actual_response_size);
 
    // Assert
   ///////////
@@ -2082,16 +2190,15 @@ int test_static_callback_note_i2c_receive_does_not_modify_buffer_parameter_addre
   uint32_t actual_response_size;
 
   Notecard notecard;
-  NoteI2c_Arduino mockI2c_arduino(Wire);  // Instantiate NoteI2c (mocked)
-  make_note_i2c_Parameters.reset();
-  make_note_i2c_Parameters.result = &mockI2c_arduino;  // Return mocked interface
-  notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
+  NoteI2c_Mock mockI2c;  // Instantiate NoteI2c (mocked)
+  notecard.begin(&mockI2c);  // Provides access to the hidden static callback methods through `note-c` mocks
+  i2cReceiveFn noteI2cReceive = noteSetFnI2C_Parameters.receivefn;
   noteI2cReceive_Parameters.reset();  // Clear the structure for testing results
 
    // Action
   ///////////
 
-  noteSetFnI2C_Parameters.receivefn(ADDRESS, response_buffer, SIZE, &actual_response_size);
+  noteI2cReceive(ADDRESS, response_buffer, SIZE, &actual_response_size);
 
    // Assert
   ///////////
@@ -2124,16 +2231,15 @@ int test_static_callback_note_i2c_receive_does_not_modify_size_parameter_before_
   uint32_t actual_response_size;
 
   Notecard notecard;
-  NoteI2c_Arduino mockI2c_arduino(Wire);  // Instantiate NoteI2c (mocked)
-  make_note_i2c_Parameters.reset();
-  make_note_i2c_Parameters.result = &mockI2c_arduino;  // Return mocked interface
-  notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
+  NoteI2c_Mock mockI2c;  // Instantiate NoteI2c (mocked)
+  notecard.begin(&mockI2c);  // Provides access to the hidden static callback methods through `note-c` mocks
+  i2cReceiveFn noteI2cReceive = noteSetFnI2C_Parameters.receivefn;
   noteI2cReceive_Parameters.reset();  // Clear the structure for testing results
 
    // Action
   ///////////
 
-  noteSetFnI2C_Parameters.receivefn(ADDRESS, response_buffer, EXPECTED_SIZE, &actual_response_size);
+  noteI2cReceive(ADDRESS, response_buffer, EXPECTED_SIZE, &actual_response_size);
 
    // Assert
   ///////////
@@ -2166,16 +2272,15 @@ int test_static_callback_note_i2c_receive_does_not_modify_available_parameter_ad
   uint32_t actual_response_size;
 
   Notecard notecard;
-  NoteI2c_Arduino mockI2c_arduino(Wire);  // Instantiate NoteI2c (mocked)
-  make_note_i2c_Parameters.reset();
-  make_note_i2c_Parameters.result = &mockI2c_arduino;  // Return mocked interface
-  notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
+  NoteI2c_Mock mockI2c;  // Instantiate NoteI2c (mocked)
+  notecard.begin(&mockI2c);  // Provides access to the hidden static callback methods through `note-c` mocks
+  i2cReceiveFn noteI2cReceive = noteSetFnI2C_Parameters.receivefn;
   noteI2cReceive_Parameters.reset();  // Clear the structure for testing results
 
    // Action
   ///////////
 
-  noteSetFnI2C_Parameters.receivefn(ADDRESS, response_buffer, SIZE, &actual_response_size);
+  noteI2cReceive(ADDRESS, response_buffer, SIZE, &actual_response_size);
 
    // Assert
   ///////////
@@ -2208,17 +2313,16 @@ int test_static_callback_note_i2c_receive_does_not_modify_interface_method_retur
   uint32_t actual_response_size;
 
   Notecard notecard;
-  NoteI2c_Arduino mockI2c_arduino(Wire);  // Instantiate NoteI2c (mocked)
-  make_note_i2c_Parameters.reset();
-  make_note_i2c_Parameters.result = &mockI2c_arduino;  // Return mocked interface
-  notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
+  NoteI2c_Mock mockI2c;  // Instantiate NoteI2c (mocked)
+  notecard.begin(&mockI2c);  // Provides access to the hidden static callback methods through `note-c` mocks
+  i2cReceiveFn noteI2cReceive = noteSetFnI2C_Parameters.receivefn;
   noteI2cReceive_Parameters.reset();  // Clear the structure for testing results
   noteI2cReceive_Parameters.result = "i2c: fake test error!";
 
    // Action
   ///////////
 
-  const char * const ACTUAL_RESULT = noteSetFnI2C_Parameters.receivefn(ADDRESS, response_buffer, SIZE, &actual_response_size);
+  const char * const ACTUAL_RESULT = noteI2cReceive(ADDRESS, response_buffer, SIZE, &actual_response_size);
 
    // Assert
   ///////////
@@ -2251,14 +2355,18 @@ int test_static_callback_note_i2c_receive_does_not_call_interface_method_when_in
   uint32_t actual_response_size;
 
   Notecard notecard;
-  make_note_i2c_Parameters.reset();
-  notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
+  NoteI2c_Mock mockI2c;
+  notecard.begin(&mockI2c);  // Provides access to the hidden static callback methods through `note-c` mocks
+  i2cReceiveFn noteI2cReceive = noteSetFnI2C_Parameters.receivefn;
+
+  // Reset to ensure the interface is not instantiated
+  notecard.begin(static_cast<NoteI2c *>(nullptr));
   noteI2cReceive_Parameters.reset();  // Clear the structure for testing results
 
    // Action
   ///////////
 
-  noteSetFnI2C_Parameters.receivefn(ADDRESS, response_buffer, SIZE, &actual_response_size);
+  noteI2cReceive(ADDRESS, response_buffer, SIZE, &actual_response_size);
 
    // Assert
   ///////////
@@ -2292,14 +2400,18 @@ int test_static_callback_note_i2c_receive_returns_error_message_when_interface_h
   const char * const EXPECTED_RESULT = "i2c: A call to Notecard::begin() is required. {io}";
 
   Notecard notecard;
-  make_note_i2c_Parameters.reset();
-  notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
+  NoteI2c_Mock mockI2c;
+  notecard.begin(&mockI2c);  // Provides access to the hidden static callback methods through `note-c` mocks
+  i2cReceiveFn noteI2cReceive = noteSetFnI2C_Parameters.receivefn;
+
+  // Reset to ensure the interface is not instantiated
+  notecard.begin(static_cast<NoteI2c *>(nullptr));
   noteI2cReceive_Parameters.reset();  // Clear the structure for testing results
 
    // Action
   ///////////
 
-  const char * const ACTUAL_RESULT = noteSetFnI2C_Parameters.receivefn(ADDRESS, response_buffer, SIZE, &actual_response_size);
+  const char * const ACTUAL_RESULT = noteI2cReceive(ADDRESS, response_buffer, SIZE, &actual_response_size);
 
    // Assert
   ///////////
@@ -2312,7 +2424,7 @@ int test_static_callback_note_i2c_receive_returns_error_message_when_interface_h
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
     std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
-    std::cout << "\tACTUAL_RESULT == " << ACTUAL_RESULT << ", EXPECTED: " << EXPECTED_RESULT << std::endl;
+    std::cout << "\tACTUAL_RESULT == " << std::string(ACTUAL_RESULT).c_str() << ", EXPECTED: " << EXPECTED_RESULT << std::endl;
     std::cout << "[";
   }
 
@@ -2329,16 +2441,15 @@ int test_static_callback_note_i2c_reset_invokes_notei2c_reset()
   const uint16_t ADDRESS = 0x17;
 
   Notecard notecard;
-  NoteI2c_Arduino mockI2c_arduino(Wire);  // Instantiate NoteI2c (mocked)
-  make_note_i2c_Parameters.reset();
-  make_note_i2c_Parameters.result = &mockI2c_arduino;  // Return mocked interface
-  notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
+  NoteI2c_Mock mockI2c;  // Instantiate NoteI2c (mocked)
+  notecard.begin(&mockI2c);  // Provides access to the hidden static callback methods through `note-c` mocks
+  i2cResetFn noteI2cReset = noteSetFnI2C_Parameters.resetfn;
   noteI2cReset_Parameters.reset();  // Clear the structure for testing results
 
    // Action
   ///////////
 
-  noteSetFnI2C_Parameters.resetfn(ADDRESS);
+  noteI2cReset(ADDRESS);
 
    // Assert
   ///////////
@@ -2369,16 +2480,15 @@ int test_static_callback_note_i2c_reset_does_not_modify_device_address_parameter
   const uint16_t EXPECTED_ADDRESS = 0x1B;
 
   Notecard notecard;
-  NoteI2c_Arduino mockI2c_arduino(Wire);  // Instantiate NoteI2c (mocked)
-  make_note_i2c_Parameters.reset();
-  make_note_i2c_Parameters.result = &mockI2c_arduino;  // Return mocked interface
-  notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
+  NoteI2c_Mock mockI2c;  // Instantiate NoteI2c (mocked)
+  notecard.begin(&mockI2c);  // Provides access to the hidden static callback methods through `note-c` mocks
+  i2cResetFn noteI2cReset = noteSetFnI2C_Parameters.resetfn;
   noteI2cReset_Parameters.reset();  // Clear the structure for testing results
 
    // Action
   ///////////
 
-  noteSetFnI2C_Parameters.resetfn(EXPECTED_ADDRESS);
+  noteI2cReset(EXPECTED_ADDRESS);
 
    // Assert
   ///////////
@@ -2408,17 +2518,16 @@ int test_static_callback_note_i2c_reset_does_not_modify_interface_method_return_
   const uint16_t ADDRESS = 0x1B;
 
   Notecard notecard;
-  NoteI2c_Arduino mockI2c_arduino(Wire);  // Instantiate NoteI2c (mocked)
-  make_note_i2c_Parameters.reset();
-  make_note_i2c_Parameters.result = &mockI2c_arduino;  // Return mocked interface
-  notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
+  NoteI2c_Mock mockI2c;  // Instantiate NoteI2c (mocked)
+  notecard.begin(&mockI2c);  // Provides access to the hidden static callback methods through `note-c` mocks
+  i2cResetFn noteI2cReset = noteSetFnI2C_Parameters.resetfn;
   noteI2cReset_Parameters.reset();  // Clear the structure for testing results
   noteI2cReset_Parameters.result = true;
 
    // Action
   ///////////
 
-  const bool ACTUAL_RESULT = noteSetFnI2C_Parameters.resetfn(ADDRESS);
+  const bool ACTUAL_RESULT = noteI2cReset(ADDRESS);
 
    // Assert
   ///////////
@@ -2448,14 +2557,18 @@ int test_static_callback_note_i2c_reset_does_not_call_interface_method_when_inte
   const uint16_t ADDRESS = 0x1B;
 
   Notecard notecard;
-  make_note_i2c_Parameters.reset();
-  notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
+  NoteI2c_Mock mockI2c;
+  notecard.begin(&mockI2c);  // Provides access to the hidden static callback methods through `note-c` mocks
+  i2cResetFn noteI2cReset = noteSetFnI2C_Parameters.resetfn;
+
+  // Reset to ensure the interface is not instantiated
+  notecard.begin(static_cast<NoteI2c *>(nullptr));
   noteI2cReset_Parameters.reset();  // Clear the structure for testing results
 
    // Action
   ///////////
 
-  noteSetFnI2C_Parameters.resetfn(ADDRESS);
+  noteI2cReset(ADDRESS);
 
    // Assert
   ///////////
@@ -2485,14 +2598,19 @@ int test_static_callback_note_i2c_reset_returns_false_when_interface_has_not_bee
   const uint16_t ADDRESS = 0x1B;
 
   Notecard notecard;
-  make_note_i2c_Parameters.reset();
-  notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
+  NoteI2c_Mock mockI2c;
+  notecard.begin(&mockI2c);  // Provides access to the hidden static callback methods through `note-c` mocks
+  i2cResetFn noteI2cReset = noteSetFnI2C_Parameters.resetfn;
+
+  // Reset to ensure the interface is not instantiated
+  notecard.begin(static_cast<NoteI2c *>(nullptr));
   noteI2cReset_Parameters.reset();  // Clear the structure for testing results
+  noteI2cReset_Parameters.result = true;  // Ensure that if the mock were to be invoked the test would fail
 
    // Action
   ///////////
 
-  const bool ACTUAL_RESULT = noteSetFnI2C_Parameters.resetfn(ADDRESS);
+  const bool ACTUAL_RESULT = noteI2cReset(ADDRESS);
 
    // Assert
   ///////////
@@ -2521,19 +2639,18 @@ int test_static_callback_note_i2c_transmit_invokes_notei2c_transmit()
 
   const uint16_t ADDRESS = 0x17;
   const uint16_t SIZE = 13;
-  uint8_t transmit_buffer[32];
+  uint8_t transmit_buffer[] = "Transmissible data";
 
   Notecard notecard;
-  NoteI2c_Arduino mockI2c_arduino(Wire);  // Instantiate NoteI2c (mocked)
-  make_note_i2c_Parameters.reset();
-  make_note_i2c_Parameters.result = &mockI2c_arduino;  // Return mocked interface
-  notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
+  NoteI2c_Mock mockI2c;  // Instantiate NoteI2c (mocked)
+  notecard.begin(&mockI2c);  // Provides access to the hidden static callback methods through `note-c` mocks
+  i2cTransmitFn noteI2cTransmit = noteSetFnI2C_Parameters.transmitfn;
   noteI2cTransmit_Parameters.reset();  // Clear the structure for testing results
 
    // Action
   ///////////
 
-  noteSetFnI2C_Parameters.transmitfn(ADDRESS, transmit_buffer, SIZE);
+  noteI2cTransmit(ADDRESS, transmit_buffer, SIZE);
 
    // Assert
   ///////////
@@ -2563,19 +2680,18 @@ int test_static_callback_note_i2c_transmit_does_not_modify_device_address_parame
   // 0x1B binary representation => 0001 1011
   const uint16_t EXPECTED_ADDRESS = 0x1B;
   const uint16_t SIZE = 13;
-  uint8_t transmit_buffer[32];
+  uint8_t transmit_buffer[] = "Transmissible data";
 
   Notecard notecard;
-  NoteI2c_Arduino mockI2c_arduino(Wire);  // Instantiate NoteI2c (mocked)
-  make_note_i2c_Parameters.reset();
-  make_note_i2c_Parameters.result = &mockI2c_arduino;  // Return mocked interface
-  notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
+  NoteI2c_Mock mockI2c;  // Instantiate NoteI2c (mocked)
+  notecard.begin(&mockI2c);  // Provides access to the hidden static callback methods through `note-c` mocks
+  i2cTransmitFn noteI2cTransmit = noteSetFnI2C_Parameters.transmitfn;
   noteI2cTransmit_Parameters.reset();  // Clear the structure for testing results
 
    // Action
   ///////////
 
-  noteSetFnI2C_Parameters.transmitfn(EXPECTED_ADDRESS, transmit_buffer, SIZE);
+  noteI2cTransmit(EXPECTED_ADDRESS, transmit_buffer, SIZE);
 
    // Assert
   ///////////
@@ -2607,16 +2723,15 @@ int test_static_callback_note_i2c_transmit_does_not_modify_buffer_parameter_befo
   uint8_t transmit_buffer[] = "Test Passed!";
 
   Notecard notecard;
-  NoteI2c_Arduino mockI2c_arduino(Wire);  // Instantiate NoteI2c (mocked)
-  make_note_i2c_Parameters.reset();
-  make_note_i2c_Parameters.result = &mockI2c_arduino;  // Return mocked interface
-  notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
+  NoteI2c_Mock mockI2c;  // Instantiate NoteI2c (mocked)
+  notecard.begin(&mockI2c);  // Provides access to the hidden static callback methods through `note-c` mocks
+  i2cTransmitFn noteI2cTransmit = noteSetFnI2C_Parameters.transmitfn;
   noteI2cTransmit_Parameters.reset();  // Clear the structure for testing results
 
    // Action
   ///////////
 
-  noteSetFnI2C_Parameters.transmitfn(ADDRESS, transmit_buffer, SIZE);
+  noteI2cTransmit(ADDRESS, transmit_buffer, SIZE);
 
    // Assert
   ///////////
@@ -2629,7 +2744,7 @@ int test_static_callback_note_i2c_transmit_does_not_modify_buffer_parameter_befo
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
     std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
-    std::cout << "\tnoteI2cTransmit_Parameters.buffer == " << noteI2cTransmit_Parameters.buffer << ", EXPECTED: " << transmit_buffer << std::endl;
+    std::cout << "\tnoteI2cTransmit_Parameters.buffer == " << noteI2cTransmit_Parameters.buffer_cache.c_str() << ", EXPECTED: " << transmit_buffer << std::endl;
     std::cout << "[";
   }
 
@@ -2645,19 +2760,18 @@ int test_static_callback_note_i2c_transmit_does_not_modify_size_parameter_before
 
   const uint16_t ADDRESS = 0x1B;
   const uint16_t EXPECTED_SIZE = 13;
-  uint8_t transmit_buffer[32];
+  uint8_t transmit_buffer[] = "Transmissible data";
 
   Notecard notecard;
-  NoteI2c_Arduino mockI2c_arduino(Wire);  // Instantiate NoteI2c (mocked)
-  make_note_i2c_Parameters.reset();
-  make_note_i2c_Parameters.result = &mockI2c_arduino;  // Return mocked interface
-  notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
+  NoteI2c_Mock mockI2c;  // Instantiate NoteI2c (mocked)
+  notecard.begin(&mockI2c);  // Provides access to the hidden static callback methods through `note-c` mocks
+  i2cTransmitFn noteI2cTransmit = noteSetFnI2C_Parameters.transmitfn;
   noteI2cTransmit_Parameters.reset();  // Clear the structure for testing results
 
    // Action
   ///////////
 
-  noteSetFnI2C_Parameters.transmitfn(ADDRESS, transmit_buffer, EXPECTED_SIZE);
+  noteI2cTransmit(ADDRESS, transmit_buffer, EXPECTED_SIZE);
 
    // Assert
   ///////////
@@ -2686,20 +2800,19 @@ int test_static_callback_note_i2c_transmit_does_not_modify_interface_method_retu
 
   const uint16_t ADDRESS = 0x1B;
   const uint16_t SIZE = 13;
-  uint8_t transmit_buffer[32];
+  uint8_t transmit_buffer[] = "Transmissible data";
 
   Notecard notecard;
-  NoteI2c_Arduino mockI2c_arduino(Wire);  // Instantiate NoteI2c (mocked)
-  make_note_i2c_Parameters.reset();
-  make_note_i2c_Parameters.result = &mockI2c_arduino;  // Return mocked interface
-  notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
+  NoteI2c_Mock mockI2c;  // Instantiate NoteI2c (mocked)
+  notecard.begin(&mockI2c);  // Provides access to the hidden static callback methods through `note-c` mocks
+  i2cTransmitFn noteI2cTransmit = noteSetFnI2C_Parameters.transmitfn;
   noteI2cTransmit_Parameters.reset();  // Clear the structure for testing results
   noteI2cTransmit_Parameters.result = "i2c: fake test error!";
 
    // Action
   ///////////
 
-  const char * const ACTUAL_RESULT = noteSetFnI2C_Parameters.transmitfn(ADDRESS, transmit_buffer, SIZE);
+  const char * const ACTUAL_RESULT = noteI2cTransmit(ADDRESS, transmit_buffer, SIZE);
 
    // Assert
   ///////////
@@ -2728,17 +2841,21 @@ int test_static_callback_note_i2c_transmit_does_not_call_interface_method_when_i
 
   const uint16_t ADDRESS = 0x1B;
   const uint16_t SIZE = 13;
-  uint8_t transmit_buffer[32];
+  uint8_t transmit_buffer[] = "Transmissible data";
 
   Notecard notecard;
-  make_note_i2c_Parameters.reset();
-  notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
+  NoteI2c_Mock mockI2c;
+  notecard.begin(&mockI2c);  // Provides access to the hidden static callback methods through `note-c` mocks
+  i2cTransmitFn noteI2cTransmit = noteSetFnI2C_Parameters.transmitfn;
+
+  // Reset to ensure the interface is not instantiated
+  notecard.begin(static_cast<NoteI2c *>(nullptr));
   noteI2cTransmit_Parameters.reset();  // Clear the structure for testing results
 
    // Action
   ///////////
 
-  noteSetFnI2C_Parameters.transmitfn(ADDRESS, transmit_buffer, SIZE);
+  noteI2cTransmit(ADDRESS, transmit_buffer, SIZE);
 
    // Assert
   ///////////
@@ -2767,18 +2884,22 @@ int test_static_callback_note_i2c_transmit_returns_error_message_when_interface_
 
   const uint16_t ADDRESS = 0x1B;
   const uint16_t SIZE = 13;
-  uint8_t transmit_buffer[32];
+  uint8_t transmit_buffer[] = "Transmissible data";
   const char * const EXPECTED_RESULT = "i2c: A call to Notecard::begin() is required. {io}";
 
   Notecard notecard;
-  make_note_i2c_Parameters.reset();
-  notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
+  NoteI2c_Mock mockI2c;
+  notecard.begin(&mockI2c);  // Provides access to the hidden static callback methods through `note-c` mocks
+  i2cTransmitFn noteI2cTransmit = noteSetFnI2C_Parameters.transmitfn;
+
+  // Reset to ensure the interface is not instantiated
+  notecard.begin(static_cast<NoteI2c *>(nullptr));
   noteI2cTransmit_Parameters.reset();  // Clear the structure for testing results
 
    // Action
   ///////////
 
-  const char * const ACTUAL_RESULT = noteSetFnI2C_Parameters.transmitfn(ADDRESS, transmit_buffer, SIZE);
+  const char * const ACTUAL_RESULT = noteI2cTransmit(ADDRESS, transmit_buffer, SIZE);
 
    // Assert
   ///////////
@@ -2791,7 +2912,7 @@ int test_static_callback_note_i2c_transmit_returns_error_message_when_interface_
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
     std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
-    std::cout << "\tACTUAL_RESULT == " << ACTUAL_RESULT << ", EXPECTED: " << EXPECTED_RESULT << std::endl;
+    std::cout << "\tACTUAL_RESULT == " << std::string(ACTUAL_RESULT).c_str() << ", EXPECTED: " << EXPECTED_RESULT << std::endl;
     std::cout << "[";
   }
 
@@ -2805,14 +2926,11 @@ int test_static_callback_note_log_print_invokes_notelog_print()
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   const char message[] = "Test passed!";
 
   Notecard notecard;
   NoteLog_Mock mockLog;  // Instantiate NoteLog (mocked)
-  make_note_log_Parameters.reset();
-  make_note_log_Parameters.result = &mockLog;  // Return mocked interface
-  notecard.setDebugOutputStream(MOCK_SERIAL_CHANNEL);  // Provides access to the hidden static callback methods through `note-c` mocks
+  notecard.setDebugOutputStream(&mockLog);  // Provides access to the hidden static callback methods through `note-c` mocks
   debugOutputFn noteLogPrint = noteSetFnDebugOutput_Parameters.fn;  // Capture the internal Notecard log function, `noteLogPrint`
   noteLogPrint_Parameters.reset();  // Clear the structure for testing NoteLog::print results
 
@@ -2846,14 +2964,11 @@ int test_static_callback_note_log_print_does_not_modify_message_parameter_before
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   const char message[] = "Test passed!";
 
   Notecard notecard;
   NoteLog_Mock mockLog;  // Instantiate NoteLog (mocked)
-  make_note_log_Parameters.reset();
-  make_note_log_Parameters.result = &mockLog;  // Return mocked interface
-  notecard.setDebugOutputStream(MOCK_SERIAL_CHANNEL);  // Provides access to the hidden static callback methods through `note-c` mocks
+  notecard.setDebugOutputStream(&mockLog);  // Provides access to the hidden static callback methods through `note-c` mocks
   debugOutputFn noteLogPrint = noteSetFnDebugOutput_Parameters.fn;  // Capture the internal Notecard log function, `noteLogPrint`
   noteLogPrint_Parameters.reset();  // Clear the structure for testing NoteLog::print results
 
@@ -2887,14 +3002,11 @@ int test_static_callback_note_log_print_does_not_modify_interface_method_return_
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   const char message[] = "Test passed!";
 
   Notecard notecard;
   NoteLog_Mock mockLog;  // Instantiate NoteLog (mocked)
-  make_note_log_Parameters.reset();
-  make_note_log_Parameters.result = &mockLog;  // Return mocked interface
-  notecard.setDebugOutputStream(MOCK_SERIAL_CHANNEL);  // Provides access to the hidden static callback methods through `note-c` mocks
+  notecard.setDebugOutputStream(&mockLog);  // Provides access to the hidden static callback methods through `note-c` mocks
   debugOutputFn noteLogPrint = noteSetFnDebugOutput_Parameters.fn;  // Capture the internal Notecard log function, `noteLogPrint`
   noteLogPrint_Parameters.reset();  // Clear the structure for testing NoteLog::print results
   noteLogPrint_Parameters.result = sizeof(message);
@@ -2929,22 +3041,17 @@ int test_static_callback_note_log_print_does_not_call_interface_method_when_inte
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   const char message[] = "Test passed!";
 
   Notecard notecard;
 
   // Capture the internal Notecard log function, `noteLogPrint`
   NoteLog_Mock mockLog;
-  make_note_log_Parameters.reset();
-  make_note_log_Parameters.result = &mockLog;
-  notecard.setDebugOutputStream(MOCK_SERIAL_CHANNEL);  // Provides access to the internal static callback methods through `note-c` mocks
+  notecard.setDebugOutputStream(&mockLog);  // Provides access to the internal static callback methods through `note-c` mocks
   debugOutputFn noteLogPrint = noteSetFnDebugOutput_Parameters.fn;  // Capture the internal Notecard log function, `noteLogPrint`
 
   // Reset to ensure interface is not instantiated
-  make_note_log_Parameters.reset();
-  make_note_log_Parameters.result = nullptr;  // Ensure interface is not instantiated
-  notecard.setDebugOutputStream(MOCK_SERIAL_CHANNEL);
+  notecard.setDebugOutputStream(nullptr);
   noteLogPrint_Parameters.reset();  // Clear the structure for testing NoteLog::print results
 
    // Action
@@ -2977,22 +3084,17 @@ int test_static_callback_note_log_print_returns_false_when_interface_has_not_bee
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   const char message[] = "Test passed!";
 
   Notecard notecard;
 
   // Capture the internal Notecard log function, `noteLogPrint`
   NoteLog_Mock mockLog;
-  make_note_log_Parameters.reset();
-  make_note_log_Parameters.result = &mockLog;
-  notecard.setDebugOutputStream(MOCK_SERIAL_CHANNEL);  // Provides access to the internal static callback methods through `note-c` mocks
+  notecard.setDebugOutputStream(&mockLog);  // Provides access to the internal static callback methods through `note-c` mocks
   debugOutputFn noteLogPrint = noteSetFnDebugOutput_Parameters.fn;  // Capture the internal Notecard log function, `noteLogPrint`
 
   // Reset to ensure interface is not instantiated
-  make_note_log_Parameters.reset();
-  make_note_log_Parameters.result = nullptr;  // Ensure interface is not instantiated
-  notecard.setDebugOutputStream(MOCK_SERIAL_CHANNEL);
+  notecard.setDebugOutputStream(nullptr);
   noteLogPrint_Parameters.reset();  // Clear the structure for testing NoteLog::print results
   noteLogPrint_Parameters.result = sizeof(message);  // Ensure that if the mock were to be invoked the test would fail
 
@@ -3026,12 +3128,9 @@ int test_static_callback_note_serial_available_invokes_noteserial_available()
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   Notecard notecard;
   NoteSerial_Mock mockSerial;  // Instantiate NoteSerial (mocked)
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = &mockSerial;  // Return mocked interface
-  notecard.begin(MOCK_SERIAL_CHANNEL);  // Provides access to the hidden static callback methods through `note-c` mocks
+  notecard.begin(&mockSerial);  // Provides access to the hidden static callback methods through `note-c` mocks
   serialAvailableFn noteSerialAvailable = noteSetFnSerial_Parameters.availfn;  // Capture the internal Notecard serial function, `noteSerialAvailable`
   noteSerialAvailable_Parameters.reset();  // Clear the structure for testing results
 
@@ -3065,12 +3164,9 @@ int test_static_callback_note_serial_available_does_not_modify_interface_method_
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   Notecard notecard;
   NoteSerial_Mock mockSerial;  // Instantiate NoteSerial (mocked)
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = &mockSerial;  // Return mocked interface
-  notecard.begin(MOCK_SERIAL_CHANNEL);  // Provides access to the hidden static callback methods through `note-c` mocks
+  notecard.begin(&mockSerial);  // Provides access to the hidden static callback methods through `note-c` mocks
   serialAvailableFn noteSerialAvailable = noteSetFnSerial_Parameters.availfn;  // Capture the internal Notecard serial function, `noteSerialAvailable`
   noteSerialAvailable_Parameters.reset();  // Clear the structure for testing results
   noteSerialAvailable_Parameters.result = true;
@@ -3105,20 +3201,15 @@ int test_static_callback_note_serial_available_does_not_call_interface_method_wh
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   Notecard notecard;
 
   // Capture the internal Notecard log function, `noteSerialAvailable`
   NoteSerial_Mock mockSerial;  // Instantiate NoteSerial (mocked)
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = &mockSerial;  // Return mocked interface
-  notecard.begin(MOCK_SERIAL_CHANNEL);  // Provides access to the hidden static callback methods through `note-c` mocks
+  notecard.begin(&mockSerial);  // Provides access to the hidden static callback methods through `note-c` mocks
   serialAvailableFn noteSerialAvailable = noteSetFnSerial_Parameters.availfn;  // Capture the internal Notecard serial function, `noteSerialAvailable`
 
   // Reset to ensure the interface is not instantiated
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = nullptr;  // Ensure interface is not instantiated
-  notecard.begin(MOCK_SERIAL_CHANNEL);
+  notecard.begin(static_cast<NoteSerial *>(nullptr));
   noteSerialAvailable_Parameters.reset();  // Clear the structure for testing results
 
    // Action
@@ -3151,20 +3242,15 @@ int test_static_callback_note_serial_available_returns_false_when_interface_has_
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   Notecard notecard;
 
   // Capture the internal Notecard log function, `noteSerialAvailable`
   NoteSerial_Mock mockSerial;  // Instantiate NoteSerial (mocked)
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = &mockSerial;  // Return mocked interface
-  notecard.begin(MOCK_SERIAL_CHANNEL);  // Provides access to the hidden static callback methods through `note-c` mocks
+  notecard.begin(&mockSerial);  // Provides access to the hidden static callback methods through `note-c` mocks
   serialAvailableFn noteSerialAvailable = noteSetFnSerial_Parameters.availfn;  // Capture the internal Notecard serial function, `noteSerialAvailable`
 
   // Reset to ensure the interface is not instantiated
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = nullptr;  // Ensure interface is not instantiated
-  notecard.begin(MOCK_SERIAL_CHANNEL);
+  notecard.begin(static_cast<NoteSerial *>(nullptr));
   noteSerialAvailable_Parameters.reset();  // Clear the structure for testing results
   noteSerialAvailable_Parameters.result = true;  // Ensure that if the mock were to be invoked the test would fail
 
@@ -3198,12 +3284,9 @@ int test_static_callback_note_serial_receive_invokes_noteserial_receive()
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   Notecard notecard;
   NoteSerial_Mock mockSerial;  // Instantiate NoteSerial (mocked)
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = &mockSerial;  // Return mocked interface
-  notecard.begin(MOCK_SERIAL_CHANNEL);  // Provides access to the hidden static callback methods through `note-c` mocks
+  notecard.begin(&mockSerial);  // Provides access to the hidden static callback methods through `note-c` mocks
   serialReceiveFn noteSerialReceive = noteSetFnSerial_Parameters.readfn;  // Capture the internal Notecard serial function, `noteSerialReceive`
   noteSerialReceive_Parameters.reset();  // Clear the structure for testing results
 
@@ -3237,12 +3320,9 @@ int test_static_callback_note_serial_receive_does_not_modify_interface_method_re
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   Notecard notecard;
   NoteSerial_Mock mockSerial;  // Instantiate NoteSerial (mocked)
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = &mockSerial;  // Return mocked interface
-  notecard.begin(MOCK_SERIAL_CHANNEL);  // Provides access to the hidden static callback methods through `note-c` mocks
+  notecard.begin(&mockSerial);  // Provides access to the hidden static callback methods through `note-c` mocks
   serialReceiveFn noteSerialReceive = noteSetFnSerial_Parameters.readfn;  // Capture the internal Notecard serial function, `noteSerialReceive`
   noteSerialReceive_Parameters.reset();  // Clear the structure for testing results
   noteSerialReceive_Parameters.result = 'Z';
@@ -3277,20 +3357,15 @@ int test_static_callback_note_serial_receive_does_not_call_interface_method_when
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   Notecard notecard;
 
   // Capture the internal Notecard log function, `noteSerialAvailable`
   NoteSerial_Mock mockSerial;  // Instantiate NoteSerial (mocked)
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = &mockSerial;  // Return mocked interface
-  notecard.begin(MOCK_SERIAL_CHANNEL);  // Provides access to the hidden static callback methods through `note-c` mocks
+  notecard.begin(&mockSerial);  // Provides access to the hidden static callback methods through `note-c` mocks
   serialReceiveFn noteSerialReceive = noteSetFnSerial_Parameters.readfn;  // Capture the internal Notecard serial function, `noteSerialReceive`
 
   // Reset to ensure the interface is not instantiated
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = nullptr;  // Ensure interface is not instantiated
-  notecard.begin(MOCK_SERIAL_CHANNEL);
+  notecard.begin(static_cast<NoteSerial *>(nullptr));
   noteSerialReceive_Parameters.reset();  // Clear the structure for testing results
 
    // Action
@@ -3323,21 +3398,16 @@ int test_static_callback_note_serial_receive_returns_false_when_interface_has_no
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   static const char EXPECTED_RESULT = '\0';
   Notecard notecard;
 
   // Capture the internal Notecard log function, `noteSerialAvailable`
   NoteSerial_Mock mockSerial;  // Instantiate NoteSerial (mocked)
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = &mockSerial;  // Return mocked interface
-  notecard.begin(MOCK_SERIAL_CHANNEL);  // Provides access to the hidden static callback methods through `note-c` mocks
+  notecard.begin(&mockSerial);  // Provides access to the hidden static callback methods through `note-c` mocks
   serialReceiveFn noteSerialReceive = noteSetFnSerial_Parameters.readfn;  // Capture the internal Notecard serial function, `noteSerialReceive`
 
   // Reset to ensure the interface is not instantiated
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = nullptr;  // Ensure interface is not instantiated
-  notecard.begin(MOCK_SERIAL_CHANNEL);
+  notecard.begin(static_cast<NoteSerial *>(nullptr));
   noteSerialReceive_Parameters.reset();  // Clear the structure for testing results
   noteSerialReceive_Parameters.result = 'Z';
 
@@ -3371,12 +3441,9 @@ int test_static_callback_note_serial_reset_invokes_noteserial_reset()
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   Notecard notecard;
   NoteSerial_Mock mockSerial;  // Instantiate NoteSerial (mocked)
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = &mockSerial;  // Return mocked interface
-  notecard.begin(MOCK_SERIAL_CHANNEL);  // Provides access to the hidden static callback methods through `note-c` mocks
+  notecard.begin(&mockSerial);  // Provides access to the hidden static callback methods through `note-c` mocks
   serialResetFn noteSerialReset = noteSetFnSerial_Parameters.resetfn;  // Capture the internal Notecard serial function, `noteSerialReset`
   noteSerialReset_Parameters.reset();  // Clear the structure for testing results
 
@@ -3410,12 +3477,9 @@ int test_static_callback_note_serial_reset_does_not_modify_interface_method_retu
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   Notecard notecard;
   NoteSerial_Mock mockSerial;  // Instantiate NoteSerial (mocked)
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = &mockSerial;  // Return mocked interface
-  notecard.begin(MOCK_SERIAL_CHANNEL);  // Provides access to the hidden static callback methods through `note-c` mocks
+  notecard.begin(&mockSerial);  // Provides access to the hidden static callback methods through `note-c` mocks
   serialResetFn noteSerialReset = noteSetFnSerial_Parameters.resetfn;  // Capture the internal Notecard serial function, `noteSerialReset`
   noteSerialReset_Parameters.reset();  // Clear the structure for testing results
   noteSerialReset_Parameters.result = true;
@@ -3450,20 +3514,15 @@ int test_static_callback_note_serial_reset_does_not_call_interface_method_when_i
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   Notecard notecard;
 
   // Capture the internal Notecard log function, `noteSerialAvailable`
   NoteSerial_Mock mockSerial;  // Instantiate NoteSerial (mocked)
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = &mockSerial;  // Return mocked interface
-  notecard.begin(MOCK_SERIAL_CHANNEL);  // Provides access to the hidden static callback methods through `note-c` mocks
+  notecard.begin(&mockSerial);  // Provides access to the hidden static callback methods through `note-c` mocks
   serialResetFn noteSerialReset = noteSetFnSerial_Parameters.resetfn;  // Capture the internal Notecard serial function, `noteSerialReset`
 
   // Reset to ensure the interface is not instantiated
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = nullptr;  // Ensure interface is not instantiated
-  notecard.begin(MOCK_SERIAL_CHANNEL);
+  notecard.begin(static_cast<NoteSerial *>(nullptr));
   noteSerialReset_Parameters.reset();  // Clear the structure for testing results
 
    // Action
@@ -3496,20 +3555,15 @@ int test_static_callback_note_serial_reset_returns_false_when_interface_has_not_
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   Notecard notecard;
 
   // Capture the internal Notecard log function, `noteSerialAvailable`
   NoteSerial_Mock mockSerial;  // Instantiate NoteSerial (mocked)
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = &mockSerial;  // Return mocked interface
-  notecard.begin(MOCK_SERIAL_CHANNEL);  // Provides access to the hidden static callback methods through `note-c` mocks
+  notecard.begin(&mockSerial);  // Provides access to the hidden static callback methods through `note-c` mocks
   serialResetFn noteSerialReset = noteSetFnSerial_Parameters.resetfn;  // Capture the internal Notecard serial function, `noteSerialReset`
 
   // Reset to ensure the interface is not instantiated
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = nullptr;  // Ensure interface is not instantiated
-  notecard.begin(MOCK_SERIAL_CHANNEL);
+  notecard.begin(static_cast<NoteSerial *>(nullptr));
   noteSerialReset_Parameters.reset();  // Clear the structure for testing results
   noteSerialReset_Parameters.result = true;
 
@@ -3543,16 +3597,13 @@ int test_static_callback_note_serial_transmit_invokes_noteserial_transmit()
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   uint8_t text[] = "Test passed!";
   static const size_t LEN = sizeof(text);
   static const bool FLUSH = true;
 
   Notecard notecard;
   NoteSerial_Mock mockSerial;  // Instantiate NoteSerial (mocked)
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = &mockSerial;  // Return mocked interface
-  notecard.begin(MOCK_SERIAL_CHANNEL);  // Provides access to the hidden static callback methods through `note-c` mocks
+  notecard.begin(&mockSerial);  // Provides access to the hidden static callback methods through `note-c` mocks
   serialTransmitFn noteSerialTransmit = noteSetFnSerial_Parameters.writefn;  // Capture the internal Notecard serial function, `noteSerialTransmit`
   noteSerialTransmit_Parameters.reset();  // Clear the structure for testing results
 
@@ -3586,16 +3637,13 @@ int test_static_callback_note_serial_transmit_does_not_modify_text_parameter_bef
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   uint8_t expected_text[] = "Test passed!";
   const size_t LEN = sizeof(expected_text);
   const bool FLUSH = true;
 
   Notecard notecard;
   NoteSerial_Mock mockSerial;  // Instantiate NoteSerial (mocked)
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = &mockSerial;  // Return mocked interface
-  notecard.begin(MOCK_SERIAL_CHANNEL);  // Provides access to the hidden static callback methods through `note-c` mocks
+  notecard.begin(&mockSerial);  // Provides access to the hidden static callback methods through `note-c` mocks
   serialTransmitFn noteSerialTransmit = noteSetFnSerial_Parameters.writefn;  // Capture the internal Notecard serial function, `noteSerialTransmit`
   noteSerialTransmit_Parameters.reset();  // Clear the structure for testing results
 
@@ -3615,7 +3663,7 @@ int test_static_callback_note_serial_transmit_does_not_modify_text_parameter_bef
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
     std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
-    std::cout << "\noteSerialTransmit_Parameters.buffer == " << noteSerialTransmit_Parameters.buffer << ", EXPECTED: " << expected_text << std::endl;
+    std::cout << "\noteSerialTransmit_Parameters.buffer == " << std::string(reinterpret_cast<char *>(noteSerialTransmit_Parameters.buffer)).c_str() << ", EXPECTED: " << expected_text << std::endl;
     std::cout << "[";
   }
 
@@ -3629,16 +3677,13 @@ int test_static_callback_note_serial_transmit_does_not_modify_length_parameter_b
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   uint8_t text[] = "Test passed!";
   const size_t EXPECTED_LEN = sizeof(text);
   const bool FLUSH = true;
 
   Notecard notecard;
   NoteSerial_Mock mockSerial;  // Instantiate NoteSerial (mocked)
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = &mockSerial;  // Return mocked interface
-  notecard.begin(MOCK_SERIAL_CHANNEL);  // Provides access to the hidden static callback methods through `note-c` mocks
+  notecard.begin(&mockSerial);  // Provides access to the hidden static callback methods through `note-c` mocks
   serialTransmitFn noteSerialTransmit = noteSetFnSerial_Parameters.writefn;  // Capture the internal Notecard serial function, `noteSerialTransmit`
   noteSerialTransmit_Parameters.reset();  // Clear the structure for testing results
 
@@ -3672,16 +3717,13 @@ int test_static_callback_note_serial_transmit_does_not_modify_flush_parameter_be
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   uint8_t text[] = "Test passed!";
   const size_t LEN = sizeof(text);
   const bool EXPECTED_FLUSH = true;
 
   Notecard notecard;
   NoteSerial_Mock mockSerial;  // Instantiate NoteSerial (mocked)
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = &mockSerial;  // Return mocked interface
-  notecard.begin(MOCK_SERIAL_CHANNEL);  // Provides access to the hidden static callback methods through `note-c` mocks
+  notecard.begin(&mockSerial);  // Provides access to the hidden static callback methods through `note-c` mocks
   serialTransmitFn noteSerialTransmit = noteSetFnSerial_Parameters.writefn;  // Capture the internal Notecard serial function, `noteSerialTransmit`
   noteSerialTransmit_Parameters.reset();  // Clear the structure for testing results
 
@@ -3715,7 +3757,6 @@ int test_static_callback_note_serial_transmit_does_not_call_interface_method_whe
    // Arrange
   ////////////
 
-  static NoteSerial::channel_t MOCK_SERIAL_CHANNEL = reinterpret_cast<void *>(0x19790917);
   uint8_t text[] = "Test passed!";
   const size_t LEN = sizeof(text);
   const bool EXPECTED_FLUSH = true;
@@ -3724,15 +3765,11 @@ int test_static_callback_note_serial_transmit_does_not_call_interface_method_whe
 
   // Capture the internal Notecard log function, `noteSerialAvailable`
   NoteSerial_Mock mockSerial;  // Instantiate NoteSerial (mocked)
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = &mockSerial;  // Return mocked interface
-  notecard.begin(MOCK_SERIAL_CHANNEL);  // Provides access to the hidden static callback methods through `note-c` mocks
+  notecard.begin(&mockSerial);  // Provides access to the hidden static callback methods through `note-c` mocks
   serialTransmitFn noteSerialTransmit = noteSetFnSerial_Parameters.writefn;  // Capture the internal Notecard serial function, `noteSerialTransmit`
 
   // Reset to ensure the interface is not instantiated
-  make_note_serial_Parameters.reset();
-  make_note_serial_Parameters.result = nullptr;  // Ensure interface is not instantiated
-  notecard.begin(MOCK_SERIAL_CHANNEL);
+  notecard.begin(static_cast<NoteSerial *>(nullptr));
   noteSerialTransmit_Parameters.reset();  // Clear the structure for testing results
 
    // Action
@@ -3761,20 +3798,28 @@ int test_static_callback_note_serial_transmit_does_not_call_interface_method_whe
 int main(void)
 {
   TestFunction tests[] = {
-      {test_notecard_begin_i2c_shares_a_memory_allocation_functon_pointer, "test_notecard_begin_i2c_shares_a_memory_allocation_functon_pointer"},
-      {test_notecard_begin_i2c_shares_a_memory_free_functon_pointer, "test_notecard_begin_i2c_shares_a_memory_free_functon_pointer"},
-      {test_notecard_begin_i2c_shares_a_delay_functon_pointer, "test_notecard_begin_i2c_shares_a_delay_functon_pointer"},
-      {test_notecard_begin_i2c_shares_a_millis_functon_pointer, "test_notecard_begin_i2c_shares_a_millis_functon_pointer"},
-      {test_notecard_begin_i2c_does_not_modify_i2c_address_parameter_before_passing_to_note_c, "test_notecard_begin_i2c_does_not_modify_i2c_address_parameter_before_passing_to_note_c"},
-      {test_notecard_begin_i2c_does_not_modify_i2c_max_parameter_before_passing_to_note_c, "test_notecard_begin_i2c_does_not_modify_i2c_max_parameter_before_passing_to_note_c"},
-      {test_notecard_begin_i2c_shares_an_i2c_reset_functon_pointer, "test_notecard_begin_i2c_shares_an_i2c_reset_functon_pointer"},
-      {test_notecard_begin_i2c_shares_an_i2c_transmit_functon_pointer, "test_notecard_begin_i2c_shares_an_i2c_transmit_functon_pointer"},
-      {test_notecard_begin_i2c_shares_an_i2c_receive_functon_pointer, "test_notecard_begin_i2c_shares_an_i2c_receive_functon_pointer"},
-      {test_notecard_begin_i2c_default_parameter_for_i2c_max_is_passed_to_note_c, "test_notecard_begin_i2c_default_parameter_for_i2c_max_is_passed_to_note_c"},
-      {test_notecard_begin_i2c_default_parameter_for_i2c_address_is_passed_to_note_c, "test_notecard_begin_i2c_default_parameter_for_i2c_address_is_passed_to_note_c"},
-      {test_notecard_begin_i2c_default_parameter_for_wirePort_instantiates_the_note_i2c_interface_with_wire, "test_notecard_begin_i2c_default_parameter_for_wirePort_instantiates_the_note_i2c_interface_with_wire"},
-      {test_notecard_begin_i2c_parameter_for_wirePort_instantiates_the_note_i2c_interface_with_wirePort, "test_notecard_begin_i2c_parameter_for_wirePort_instantiates_the_note_i2c_interface_with_wirePort"},
       {test_notecard_begin_i2c_sets_user_agent_to_note_arduino, "test_notecard_begin_i2c_sets_user_agent_to_note_arduino"},
+      {test_notecard_begin_i2c_sets_user_agent_to_note_arduino_when_interface_has_not_been_instantiated, "test_notecard_begin_i2c_sets_user_agent_to_note_arduino_when_interface_has_not_been_instantiated"},
+      {test_notecard_begin_i2c_shares_a_memory_allocation_functon_pointer, "test_notecard_begin_i2c_shares_a_memory_allocation_functon_pointer"},
+      {test_notecard_begin_i2c_sets_memory_allocation_functon_pointer_to_nullptr_when_interface_has_not_been_instantiated, "test_notecard_begin_i2c_sets_memory_allocation_functon_pointer_to_nullptr_when_interface_has_not_been_instantiated"},
+      {test_notecard_begin_i2c_shares_a_memory_free_functon_pointer, "test_notecard_begin_i2c_shares_a_memory_free_functon_pointer"},
+      {test_notecard_begin_i2c_sets_memory_free_functon_pointer_to_nullptr_when_interface_has_not_been_instantiated, "test_notecard_begin_i2c_sets_memory_free_functon_pointer_to_nullptr_when_interface_has_not_been_instantiated"},
+      {test_notecard_begin_i2c_shares_a_delay_functon_pointer, "test_notecard_begin_i2c_shares_a_delay_functon_pointer"},
+      {test_notecard_begin_i2c_sets_delay_functon_pointer_to_nullptr_when_interface_has_not_been_instantiated, "test_notecard_begin_i2c_sets_delay_functon_pointer_to_nullptr_when_interface_has_not_been_instantiated"},
+      {test_notecard_begin_i2c_shares_a_millis_functon_pointer, "test_notecard_begin_i2c_shares_a_millis_functon_pointer"},
+      {test_notecard_begin_i2c_sets_millis_functon_pointer_to_nullptr_when_interface_has_not_been_instantiated, "test_notecard_begin_i2c_sets_millis_functon_pointer_to_nullptr_when_interface_has_not_been_instantiated"},
+      {test_notecard_begin_i2c_does_not_modify_i2c_address_parameter_before_passing_to_note_c, "test_notecard_begin_i2c_does_not_modify_i2c_address_parameter_before_passing_to_note_c"},
+      {test_notecard_begin_i2c_sets_i2c_address_parameter_to_zero_before_passing_to_note_c_when_interface_has_not_been_instantiated, "test_notecard_begin_i2c_sets_i2c_address_parameter_to_zero_before_passing_to_note_c_when_interface_has_not_been_instantiated"},
+      {test_notecard_begin_i2c_does_not_modify_i2c_max_parameter_before_passing_to_note_c, "test_notecard_begin_i2c_does_not_modify_i2c_max_parameter_before_passing_to_note_c"},
+      {test_notecard_begin_i2c_sets_i2c_max_parameter_to_zero_before_passing_to_note_c_when_interface_has_not_been_instantiated, "test_notecard_begin_i2c_sets_i2c_max_parameter_to_zero_before_passing_to_note_c_when_interface_has_not_been_instantiated"},
+      {test_notecard_begin_i2c_shares_an_i2c_reset_functon_pointer, "test_notecard_begin_i2c_shares_an_i2c_reset_functon_pointer"},
+      {test_notecard_begin_i2c_sets_i2c_reset_functon_pointer_to_nullptr_when_interface_has_not_been_instantiated, "test_notecard_begin_i2c_sets_i2c_reset_functon_pointer_to_nullptr_when_interface_has_not_been_instantiated"},
+      {test_notecard_begin_i2c_shares_an_i2c_transmit_functon_pointer, "test_notecard_begin_i2c_shares_an_i2c_transmit_functon_pointer"},
+      {test_notecard_begin_i2c_sets_i2c_transmit_functon_pointer_to_nullptr_when_interface_has_not_been_instantiated, "test_notecard_begin_i2c_sets_i2c_transmit_functon_pointer_to_nullptr_when_interface_has_not_been_instantiated"},
+      {test_notecard_begin_i2c_shares_an_i2c_receive_functon_pointer, "test_notecard_begin_i2c_shares_an_i2c_receive_functon_pointer"},
+      {test_notecard_begin_i2c_sets_i2c_receive_functon_pointer_to_nullptr_when_interface_has_not_been_instantiated, "test_notecard_begin_i2c_sets_i2c_receive_functon_pointer_to_nullptr_when_interface_has_not_been_instantiated"},
+      {test_notecard_begin_i2c_default_parameter_for_i2cMax_is_passed_to_note_c, "test_notecard_begin_i2c_default_parameter_for_i2c_max_is_passed_to_note_c"},
+      {test_notecard_begin_i2c_default_parameter_for_i2cAddress_is_passed_to_note_c, "test_notecard_begin_i2c_default_parameter_for_i2c_address_is_passed_to_note_c"},
       {test_notecard_begin_serial_sets_user_agent_to_note_arduino, "test_notecard_begin_serial_sets_user_agent_to_note_arduino"},
       {test_notecard_begin_serial_sets_user_agent_to_note_arduino_when_interface_has_not_been_instantiated, "test_notecard_begin_serial_sets_user_agent_to_note_arduino_when_interface_has_not_been_instantiated"},
       {test_notecard_begin_serial_shares_a_memory_allocation_functon_pointer, "test_notecard_begin_serial_shares_a_memory_allocation_functon_pointer"},
@@ -3793,9 +3838,6 @@ int main(void)
       {test_notecard_begin_serial_sets_serial_available_functon_pointer_to_nullptr_when_interface_has_not_been_instantiated, "test_notecard_begin_serial_sets_serial_available_functon_pointer_to_nullptr_when_interface_has_not_been_instantiated"},
       {test_notecard_begin_serial_shares_a_serial_receive_functon_pointer, "test_notecard_begin_serial_shares_a_serial_receive_functon_pointer"},
       {test_notecard_begin_serial_sets_serial_receive_functon_pointer_to_nullptr_when_interface_has_not_been_instantiated, "test_notecard_begin_serial_sets_serial_receive_functon_pointer_to_nullptr_when_interface_has_not_been_instantiated"},
-      {test_notecard_begin_serial_initializes_the_provided_serial_interface_with_provided_speed, "test_notecard_begin_serial_initializes_the_provided_serial_interface_with_provided_speed"},
-      {test_notecard_begin_serial_initializes_the_provided_serial_interface_with_default_speed, "test_notecard_begin_serial_initializes_the_provided_serial_interface_with_default_speed"},
-      {test_notecard_setDebugOutputStream_does_not_modify_log_channel_parameter_before_passing_to_make_note_log, "test_notecard_setDebugOutputStream_does_not_modify_log_channel_parameter_before_passing_to_make_note_log"},
       {test_notecard_setDebugOutputStream_shares_a_debug_log_functon_pointer, "test_notecard_setDebugOutputStream_shares_a_debug_log_functon_pointer"},
       {test_notecard_setDebugOutputStream_clears_the_debug_log_functon_pointer_when_nullptr_is_provided, "test_notecard_setDebugOutputStream_clears_the_debug_log_functon_pointer_when_nullptr_is_provided"},
       {test_notecard_clearDebugOutputStream_clears_the_debug_log_functon_pointer, "test_notecard_clearDebugOutputStream_clears_the_debug_log_functon_pointer"},
@@ -3831,8 +3873,8 @@ int main(void)
       {test_static_callback_note_i2c_transmit_invokes_notei2c_transmit, "test_static_callback_note_i2c_transmit_invokes_notei2c_transmit"},
       {test_static_callback_note_i2c_transmit_does_not_modify_device_address_parameter_before_passing_to_interface_method, "test_static_callback_note_i2c_transmit_does_not_modify_device_address_parameter_before_passing_to_interface_method"},
       {test_static_callback_note_i2c_transmit_does_not_modify_buffer_parameter_before_passing_to_interface_method, "test_static_callback_note_i2c_transmit_does_not_modify_buffer_parameter_before_passing_to_interface_method"},
-      {test_static_callback_note_i2c_transmit_does_not_modify_interface_method_return_value, "test_static_callback_note_i2c_transmit_does_not_modify_interface_method_return_value"},
       {test_static_callback_note_i2c_transmit_does_not_modify_size_parameter_before_passing_to_interface_method, "test_static_callback_note_i2c_transmit_does_not_modify_size_parameter_before_passing_to_interface_method"},
+      {test_static_callback_note_i2c_transmit_does_not_modify_interface_method_return_value, "test_static_callback_note_i2c_transmit_does_not_modify_interface_method_return_value"},
       {test_static_callback_note_i2c_transmit_does_not_call_interface_method_when_interface_has_not_been_instantiated, "test_static_callback_note_i2c_transmit_does_not_call_interface_method_when_interface_has_not_been_instantiated"},
       {test_static_callback_note_i2c_transmit_returns_error_message_when_interface_has_not_been_instantiated, "test_static_callback_note_i2c_transmit_returns_error_message_when_interface_has_not_been_instantiated"},
       {test_static_callback_note_log_print_invokes_notelog_print, "test_static_callback_note_log_print_invokes_notelog_print"},

--- a/test/Notecard.test.cpp
+++ b/test/Notecard.test.cpp
@@ -5,7 +5,6 @@
 
 #include "Notecard.h"
 #include "NoteI2c_Arduino.hpp"
-#include "NoteLog_Arduino.hpp"
 #include "NoteSerial_Arduino.hpp"
 #include "TestFunction.hpp"
 #include "mock/mock-arduino.hpp"
@@ -20,15 +19,21 @@ int test_notecard_begin_i2c_shares_a_memory_allocation_functon_pointer()
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
 
   noteSetFnDefault_Parameters.reset();
 
-  // Action
+   // Action
+  ///////////
+
   notecard.begin(0x1B, 79);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (noteSetFnDefault_Parameters.mallocfn)
   {
     result = 0;
@@ -36,7 +41,7 @@ int test_notecard_begin_i2c_shares_a_memory_allocation_functon_pointer()
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteSetFnDefault_Parameters.mallocfn == " << !!noteSetFnDefault_Parameters.mallocfn << ", EXPECTED: not 0 (`nullptr`)" << std::endl;
     std::cout << "[";
   }
@@ -48,15 +53,21 @@ int test_notecard_begin_i2c_shares_a_memory_free_functon_pointer()
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
 
   noteSetFnDefault_Parameters.reset();
 
-  // Action
+   // Action
+  ///////////
+
   notecard.begin(0x1B, 79);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (noteSetFnDefault_Parameters.freefn)
   {
     result = 0;
@@ -64,7 +75,7 @@ int test_notecard_begin_i2c_shares_a_memory_free_functon_pointer()
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteSetFnDefault_Parameters.freefn == " << !!noteSetFnDefault_Parameters.freefn << ", EXPECTED: not 0 (`nullptr`)" << std::endl;
     std::cout << "[";
   }
@@ -76,15 +87,21 @@ int test_notecard_begin_i2c_shares_a_delay_functon_pointer()
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
 
   noteSetFnDefault_Parameters.reset();
 
-  // Action
+   // Action
+  ///////////
+
   notecard.begin(0x1B, 79);
 
-  // Arrange
+   // Arrange
+  ////////////
+
   if (noteSetFnDefault_Parameters.delayfn)
   {
     result = 0;
@@ -92,7 +109,7 @@ int test_notecard_begin_i2c_shares_a_delay_functon_pointer()
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteSetFnDefault_Parameters.delayfn == " << !!noteSetFnDefault_Parameters.delayfn << ", EXPECTED: not 0 (`nullptr`)" << std::endl;
     std::cout << "[";
   }
@@ -104,15 +121,21 @@ int test_notecard_begin_i2c_shares_a_millis_functon_pointer()
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
 
   noteSetFnDefault_Parameters.reset();
 
-  // Action
+   // Action
+  ///////////
+
   notecard.begin(0x1B, 79);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (noteSetFnDefault_Parameters.millisfn)
   {
     result = 0;
@@ -120,7 +143,7 @@ int test_notecard_begin_i2c_shares_a_millis_functon_pointer()
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteSetFnDefault_Parameters.millisfn == " << !!noteSetFnDefault_Parameters.millisfn << ", EXPECTED: not 0 (`nullptr`)" << std::endl;
     std::cout << "[";
   }
@@ -132,17 +155,23 @@ int test_notecard_begin_i2c_does_not_modify_i2c_address_parameter_before_passing
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
   // 0x1B binary representation => 0001 1011
   const uint16_t EXPECTED_ADDRESS = 0x1B;
 
   noteSetFnI2C_Parameters.reset();
 
-  // Action
+   // Action
+  ///////////
+
   notecard.begin(EXPECTED_ADDRESS, 79);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (EXPECTED_ADDRESS == noteSetFnI2C_Parameters.i2caddr)
   {
     result = 0;
@@ -150,7 +179,7 @@ int test_notecard_begin_i2c_does_not_modify_i2c_address_parameter_before_passing
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteSetFnI2C_Parameters.i2caddr == " << noteSetFnI2C_Parameters.i2caddr << ", EXPECTED: " << EXPECTED_ADDRESS << std::endl;
     std::cout << "[";
   }
@@ -162,16 +191,22 @@ int test_notecard_begin_i2c_does_not_modify_i2c_max_parameter_before_passing_to_
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
   const uint32_t EXPECTED_RESULT = 79;
 
   noteSetFnI2C_Parameters.reset();
 
-  // Action
+   // Action
+  ///////////
+
   notecard.begin(0x1B, EXPECTED_RESULT);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (EXPECTED_RESULT == noteSetFnI2C_Parameters.i2cmax)
   {
     result = 0;
@@ -179,7 +214,7 @@ int test_notecard_begin_i2c_does_not_modify_i2c_max_parameter_before_passing_to_
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteSetFnI2C_Parameters.i2cmax == " << noteSetFnI2C_Parameters.i2cmax << ", EXPECTED: " << EXPECTED_RESULT << std::endl;
     std::cout << "[";
   }
@@ -191,15 +226,21 @@ int test_notecard_begin_i2c_shares_an_i2c_reset_functon_pointer()
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
 
   noteSetFnI2C_Parameters.reset();
 
-  // Action
+   // Action
+  ///////////
+
   notecard.begin(0x1B, 79);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (noteSetFnI2C_Parameters.resetfn)
   {
     result = 0;
@@ -207,7 +248,7 @@ int test_notecard_begin_i2c_shares_an_i2c_reset_functon_pointer()
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteSetFnI2C_Parameters.resetfn == " << !!noteSetFnI2C_Parameters.resetfn << ", EXPECTED: not 0 (`nullptr`)" << std::endl;
     std::cout << "[";
   }
@@ -219,15 +260,21 @@ int test_notecard_begin_i2c_shares_an_i2c_transmit_functon_pointer()
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
 
   noteSetFnI2C_Parameters.reset();
 
-  // Action
+   // Action
+  ///////////
+
   notecard.begin(0x1B, 79);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (noteSetFnI2C_Parameters.transmitfn)
   {
     result = 0;
@@ -235,7 +282,7 @@ int test_notecard_begin_i2c_shares_an_i2c_transmit_functon_pointer()
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteSetFnI2C_Parameters.transmitfn == " << !!noteSetFnI2C_Parameters.transmitfn << ", EXPECTED: not 0 (`nullptr`)" << std::endl;
     std::cout << "[";
   }
@@ -247,15 +294,21 @@ int test_notecard_begin_i2c_shares_an_i2c_receive_functon_pointer()
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
 
   noteSetFnI2C_Parameters.reset();
 
-  // Action
+   // Action
+  ///////////
+
   notecard.begin(0x1B, 79);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (noteSetFnI2C_Parameters.receivefn)
   {
     result = 0;
@@ -263,7 +316,7 @@ int test_notecard_begin_i2c_shares_an_i2c_receive_functon_pointer()
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteSetFnI2C_Parameters.receivefn == " << !!noteSetFnI2C_Parameters.receivefn << ", EXPECTED: not 0 (`nullptr`)" << std::endl;
     std::cout << "[";
   }
@@ -275,16 +328,22 @@ int test_notecard_begin_i2c_default_parameter_for_i2c_max_is_passed_to_note_c()
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
 
   noteSetFnI2C_Parameters.reset();
   noteSetFnI2C_Parameters.i2cmax = (NOTE_I2C_MAX_DEFAULT - 1);
 
-  // Action
+   // Action
+  ///////////
+
   notecard.begin(0x1B);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (NOTE_I2C_MAX_DEFAULT == noteSetFnI2C_Parameters.i2cmax)
   {
     result = 0;
@@ -292,7 +351,7 @@ int test_notecard_begin_i2c_default_parameter_for_i2c_max_is_passed_to_note_c()
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteSetFnI2C_Parameters.i2cmax == " << noteSetFnI2C_Parameters.i2cmax << ", EXPECTED: " << NOTE_I2C_MAX_DEFAULT << std::endl;
     std::cout << "[";
   }
@@ -304,16 +363,22 @@ int test_notecard_begin_i2c_default_parameter_for_i2c_address_is_passed_to_note_
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
 
   noteSetFnI2C_Parameters.reset();
   noteSetFnI2C_Parameters.i2caddr = (NOTE_I2C_ADDR_DEFAULT - 1);
 
-  // Action
+   // Action
+  ///////////
+
   notecard.begin();
 
-  // Assert
+   // Assert
+  ///////////
+
   if (NOTE_I2C_ADDR_DEFAULT == noteSetFnI2C_Parameters.i2caddr)
   {
     result = 0;
@@ -321,7 +386,7 @@ int test_notecard_begin_i2c_default_parameter_for_i2c_address_is_passed_to_note_
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteSetFnI2C_Parameters.i2caddr == " << noteSetFnI2C_Parameters.i2caddr << ", EXPECTED: " << NOTE_I2C_ADDR_DEFAULT << std::endl;
     std::cout << "[";
   }
@@ -333,15 +398,21 @@ int test_notecard_begin_i2c_default_parameter_for_wirePort_instantiates_the_note
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
 
   make_note_i2c_Parameters.reset();
 
-  // Action
+   // Action
+  ///////////
+
   notecard.begin();
 
-  // Assert
+   // Assert
+  ///////////
+
   if (&Wire == make_note_i2c_Parameters.i2c_bus)
   {
     result = 0;
@@ -349,7 +420,7 @@ int test_notecard_begin_i2c_default_parameter_for_wirePort_instantiates_the_note
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tmake_note_i2c_Parameters.i2c_bus == " << !!make_note_i2c_Parameters.i2c_bus << ", EXPECTED: " << &Wire << std::endl;
     std::cout << "[";
   }
@@ -361,16 +432,22 @@ int test_notecard_begin_i2c_parameter_for_wirePort_instantiates_the_note_i2c_int
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
   TwoWire mockWire;
 
   make_note_i2c_Parameters.reset();
 
-  // Action
+   // Action
+  ///////////
+
   notecard.begin(NOTE_I2C_ADDR_DEFAULT, NOTE_I2C_MAX_DEFAULT, mockWire);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (&mockWire == make_note_i2c_Parameters.i2c_bus)
   {
     result = 0;
@@ -378,7 +455,7 @@ int test_notecard_begin_i2c_parameter_for_wirePort_instantiates_the_note_i2c_int
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tmake_note_i2c_Parameters.i2c_bus == " << make_note_i2c_Parameters.i2c_bus << ", EXPECTED: " << &mockWire << std::endl;
     std::cout << "[";
   }
@@ -390,16 +467,22 @@ int test_notecard_begin_i2c_sets_user_agent_to_note_arduino()
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   const char * const EXPECTED_USER_AGENT = "note-arduino";
   Notecard notecard;
 
   noteSetUserAgent_Parameters.reset();
 
-  // Action
+   // Action
+  ///////////
+
   notecard.begin();
 
-  // Assert
+   // Assert
+  ///////////
+
   if (noteSetUserAgent_Parameters.agent && !strcmp(EXPECTED_USER_AGENT, noteSetUserAgent_Parameters.agent))
   {
     result = 0;
@@ -407,7 +490,7 @@ int test_notecard_begin_i2c_sets_user_agent_to_note_arduino()
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteSetUserAgent_Parameters.agent == " << noteSetUserAgent_Parameters.agent << ", EXPECTED: " << EXPECTED_USER_AGENT << std::endl;
     std::cout << "[";
   }
@@ -419,15 +502,21 @@ int test_notecard_begin_serial_shares_a_memory_allocation_functon_pointer()
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
 
   noteSetFnDefault_Parameters.reset();
 
-  // Action
+   // Action
+  ///////////
+
   notecard.begin(Serial, 9600);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (noteSetFnDefault_Parameters.mallocfn)
   {
     result = 0;
@@ -435,7 +524,7 @@ int test_notecard_begin_serial_shares_a_memory_allocation_functon_pointer()
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteSetFnDefault_Parameters.mallocfn == " << !!noteSetFnDefault_Parameters.mallocfn << ", EXPECTED: not 0 (`nullptr`)" << std::endl;
     std::cout << "[";
   }
@@ -447,15 +536,21 @@ int test_notecard_begin_serial_shares_a_memory_free_functon_pointer()
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
 
   noteSetFnDefault_Parameters.reset();
 
-  // Action
+   // Action
+  ///////////
+
   notecard.begin(Serial, 9600);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (noteSetFnDefault_Parameters.freefn)
   {
     result = 0;
@@ -463,7 +558,7 @@ int test_notecard_begin_serial_shares_a_memory_free_functon_pointer()
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteSetFnDefault_Parameters.freefn == " << !!noteSetFnDefault_Parameters.freefn << ", EXPECTED: not 0 (`nullptr`)" << std::endl;
     std::cout << "[";
   }
@@ -475,15 +570,21 @@ int test_notecard_begin_serial_shares_a_delay_functon_pointer()
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
 
   noteSetFnDefault_Parameters.reset();
 
-  // Action
+   // Action
+  ///////////
+
   notecard.begin(Serial, 9600);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (noteSetFnDefault_Parameters.delayfn)
   {
     result = 0;
@@ -491,7 +592,7 @@ int test_notecard_begin_serial_shares_a_delay_functon_pointer()
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteSetFnDefault_Parameters.delayfn == " << !!noteSetFnDefault_Parameters.delayfn << ", EXPECTED: not 0 (`nullptr`)" << std::endl;
     std::cout << "[";
   }
@@ -503,15 +604,21 @@ int test_notecard_begin_serial_shares_a_millis_functon_pointer()
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
 
   noteSetFnDefault_Parameters.reset();
 
-  // Action
+   // Action
+  ///////////
+
   notecard.begin(Serial, 9600);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (nullptr != noteSetFnDefault_Parameters.millisfn)
   {
     result = 0;
@@ -519,7 +626,7 @@ int test_notecard_begin_serial_shares_a_millis_functon_pointer()
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteSetFnDefault_Parameters.millisfn == " << !!noteSetFnDefault_Parameters.millisfn << ", EXPECTED: not 0 (`nullptr`)" << std::endl;
     std::cout << "[";
   }
@@ -531,15 +638,21 @@ int test_notecard_begin_serial_shares_a_serial_reset_functon_pointer()
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
 
   noteSetFnSerial_Parameters.reset();
 
-  // Action
+   // Action
+  ///////////
+
   notecard.begin(Serial, 9600);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (noteSetFnSerial_Parameters.resetfn)
   {
     result = 0;
@@ -547,7 +660,7 @@ int test_notecard_begin_serial_shares_a_serial_reset_functon_pointer()
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteSetFnSerial_Parameters.resetfn == " << !!noteSetFnSerial_Parameters.resetfn << ", EXPECTED: not 0 (`nullptr`)" << std::endl;
     std::cout << "[";
   }
@@ -559,15 +672,21 @@ int test_notecard_begin_serial_shares_a_serial_transmit_functon_pointer()
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
 
   noteSetFnSerial_Parameters.reset();
 
-  // Action
+   // Action
+  ///////////
+
   notecard.begin(Serial, 9600);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (noteSetFnSerial_Parameters.writefn)
   {
     result = 0;
@@ -575,7 +694,7 @@ int test_notecard_begin_serial_shares_a_serial_transmit_functon_pointer()
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteSetFnSerial_Parameters.writefn == " << !!noteSetFnSerial_Parameters.writefn << ", EXPECTED: not 0 (`nullptr`)" << std::endl;
     std::cout << "[";
   }
@@ -587,15 +706,21 @@ int test_notecard_begin_serial_shares_a_serial_available_functon_pointer()
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
 
   noteSetFnSerial_Parameters.reset();
 
-  // Action
+   // Action
+  ///////////
+
   notecard.begin(Serial, 9600);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (noteSetFnSerial_Parameters.availfn)
   {
     result = 0;
@@ -603,7 +728,7 @@ int test_notecard_begin_serial_shares_a_serial_available_functon_pointer()
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteSetFnSerial_Parameters.availfn == " << !!noteSetFnSerial_Parameters.availfn << ", EXPECTED: not 0 (`nullptr`)" << std::endl;
     std::cout << "[";
   }
@@ -615,15 +740,21 @@ int test_notecard_begin_serial_shares_a_serial_receive_functon_pointer()
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
 
   noteSetFnSerial_Parameters.reset();
 
-  // Action
+   // Action
+  ///////////
+
   notecard.begin(Serial, 9600);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (noteSetFnSerial_Parameters.readfn)
   {
     result = 0;
@@ -631,7 +762,7 @@ int test_notecard_begin_serial_shares_a_serial_receive_functon_pointer()
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteSetFnSerial_Parameters.readfn == " << !!noteSetFnSerial_Parameters.readfn << ", EXPECTED: not 0 (`nullptr`)" << std::endl;
     std::cout << "[";
   }
@@ -643,16 +774,22 @@ int test_notecard_begin_serial_initializes_the_provided_serial_interface_with_pr
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
   const unsigned int EXPECTED_BAUD_RATE = 9600;
 
   make_note_serial_Parameters.reset();
 
-  // Action
+   // Action
+  ///////////
+
   notecard.begin(Serial, EXPECTED_BAUD_RATE);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (EXPECTED_BAUD_RATE == make_note_serial_Parameters.baud_rate)
   {
     result = 0;
@@ -660,7 +797,7 @@ int test_notecard_begin_serial_initializes_the_provided_serial_interface_with_pr
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tmake_note_serial_Parameters.baud_rate == " << make_note_serial_Parameters.baud_rate << ", EXPECTED: " << EXPECTED_BAUD_RATE << std::endl;
     std::cout << "[";
   }
@@ -672,16 +809,22 @@ int test_notecard_begin_serial_initializes_the_provided_serial_interface_with_de
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
   const unsigned int EXPECTED_BAUD_RATE = 9600;
 
   make_note_serial_Parameters.reset();
 
-  // Action
+   // Action
+  ///////////
+
   notecard.begin(Serial);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (EXPECTED_BAUD_RATE == make_note_serial_Parameters.baud_rate)
   {
     result = 0;
@@ -689,7 +832,7 @@ int test_notecard_begin_serial_initializes_the_provided_serial_interface_with_de
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tmake_note_serial_Parameters.baud_rate == " << make_note_serial_Parameters.baud_rate << ", EXPECTED: " << EXPECTED_BAUD_RATE << std::endl;
     std::cout << "[";
   }
@@ -701,16 +844,22 @@ int test_notecard_begin_serial_sets_user_agent_to_note_arduino()
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   const char * const EXPECTED_USER_AGENT = "note-arduino";
   Notecard notecard;
 
   noteSetUserAgent_Parameters.reset();
 
-  // Action
+   // Action
+  ///////////
+
   notecard.begin(Serial);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (noteSetUserAgent_Parameters.agent && !strcmp(EXPECTED_USER_AGENT, noteSetUserAgent_Parameters.agent))
   {
     result = 0;
@@ -718,8 +867,42 @@ int test_notecard_begin_serial_sets_user_agent_to_note_arduino()
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteSetUserAgent_Parameters.agent == " << noteSetUserAgent_Parameters.agent << ", EXPECTED: " << EXPECTED_USER_AGENT << std::endl;
+    std::cout << "[";
+  }
+
+  return result;
+}
+
+int test_notecard_setDebugOutputStream_does_not_modify_log_channel_parameter_before_passing_to_make_note_log()
+{
+  int result;
+
+   // Arrange
+  ////////////
+
+  Notecard notecard;
+
+  make_note_log_Parameters.reset();
+
+   // Action
+  ///////////
+
+  notecard.setDebugOutputStream(&Serial);
+
+   // Assert
+  ///////////
+
+  if (&Serial == make_note_log_Parameters.log_channel)
+  {
+    result = 0;
+  }
+  else
+  {
+    result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\tmake_note_log_Parameters.log_channel == " << make_note_log_Parameters.log_channel << ", EXPECTED: " << &Serial << std::endl;
     std::cout << "[";
   }
 
@@ -730,15 +913,24 @@ int test_notecard_setDebugOutputStream_shares_a_debug_log_functon_pointer()
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
 
+  make_note_log_Parameters.reset();
   noteSetFnDebugOutput_Parameters.reset();
 
-  // Action
-  notecard.setDebugOutputStream(Serial);
+  make_note_log_Parameters.result = reinterpret_cast<NoteLog *>(&result);
 
-  // Assert
+   // Action
+  ///////////
+
+  notecard.setDebugOutputStream(&Serial);
+
+   // Assert
+  ///////////
+
   if (noteSetFnDebugOutput_Parameters.fn)
   {
     result = 0;
@@ -746,8 +938,44 @@ int test_notecard_setDebugOutputStream_shares_a_debug_log_functon_pointer()
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteSetFnDebugOutput_Parameters.fn == " << !!noteSetFnDebugOutput_Parameters.fn << ", EXPECTED: not 0 (`nullptr`)" << std::endl;
+    std::cout << "[";
+  }
+
+  return result;
+}
+
+int test_notecard_setDebugOutputStream_clears_the_debug_log_functon_pointer_when_nullptr_is_provided()
+{
+  int result;
+
+   // Arrange
+  ////////////
+
+  Notecard notecard;
+
+  make_note_log_Parameters.reset();
+  noteSetFnDebugOutput_Parameters.reset();
+  noteSetFnDebugOutput_Parameters.fn = reinterpret_cast<debugOutputFn>(&result);
+
+   // Action
+  ///////////
+
+  notecard.setDebugOutputStream(nullptr);
+
+   // Assert
+  ///////////
+
+  if (!noteSetFnDebugOutput_Parameters.fn)
+  {
+    result = 0;
+  }
+  else
+  {
+    result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\tnoteSetFnDebugOutput_Parameters.fn == " << !!noteSetFnDebugOutput_Parameters.fn << ", EXPECTED: 0 (`nullptr`)" << std::endl;
     std::cout << "[";
   }
 
@@ -758,16 +986,22 @@ int test_notecard_clearDebugOutputStream_clears_the_debug_log_functon_pointer()
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
 
   noteSetFnDebugOutput_Parameters.reset();
   noteSetFnDebugOutput_Parameters.fn = reinterpret_cast<debugOutputFn>(&result);
 
-  // Action
+   // Action
+  ///////////
+
   notecard.clearDebugOutputStream();
 
-  // Assert
+   // Assert
+  ///////////
+
   if (!noteSetFnDebugOutput_Parameters.fn)
   {
     result = 0;
@@ -775,7 +1009,7 @@ int test_notecard_clearDebugOutputStream_clears_the_debug_log_functon_pointer()
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteSetFnDebugOutput_Parameters.fn == " << !!noteSetFnDebugOutput_Parameters.fn << ", EXPECTED: 0 (`nullptr`)" << std::endl;
     std::cout << "[";
   }
@@ -787,16 +1021,22 @@ int test_notecard_newRequest_does_not_modify_string_parameter_value_before_passi
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
   const char * const EXPECTED_RESULT = "Hello, Test!";
 
   noteNewRequest_Parameters.reset();
 
-  // Action
+   // Action
+  ///////////
+
   notecard.newRequest(EXPECTED_RESULT);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (!strcmp(EXPECTED_RESULT, noteNewRequest_Parameters.request_cache.c_str()))
   {
     result = 0;
@@ -804,7 +1044,7 @@ int test_notecard_newRequest_does_not_modify_string_parameter_value_before_passi
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteNewRequest_Parameters.request_cache.c_str() == \"" << noteNewRequest_Parameters.request_cache.c_str() << "\", EXPECTED: \"" << EXPECTED_RESULT << "\"" << std::endl;
     std::cout << "[";
   }
@@ -816,7 +1056,9 @@ int test_notecard_newRequest_does_not_modify_note_c_result_value_before_returnin
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
   J * const EXPECTED_JSON = reinterpret_cast<J *>(malloc(sizeof(J))); // JCreateObject();
   assert(nullptr != EXPECTED_JSON);
@@ -829,10 +1071,14 @@ int test_notecard_newRequest_does_not_modify_note_c_result_value_before_returnin
     memcpy(noteNewRequest_Parameters.result, EXPECTED_JSON, sizeof(J));
   } //assert(nullptr != (noteNewRequest_Parameters.result = JDuplicate(EXPECTED_JSON,true)));
 
-  // Action
+   // Action
+  ///////////
+
   const J * const ACTUAL_RESULT = notecard.newRequest(nullptr);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (!memcmp(ACTUAL_RESULT, EXPECTED_JSON, sizeof(J)) /*JCompare(EXPECTED_JSON, json_result, false)*/)
   {
     result = 0;
@@ -840,7 +1086,7 @@ int test_notecard_newRequest_does_not_modify_note_c_result_value_before_returnin
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnotecard.newRequest(nullptr) != EXPECTED_JSON" << std::endl;
     std::cout << "[";
   }
@@ -854,7 +1100,9 @@ int test_notecard_sendRequest_does_not_modify_j_object_parameter_value_before_pa
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
   J * EXPECTED_JSON = reinterpret_cast<J *>(malloc(sizeof(J))); // JCreateObject();
   J * json_cpy;
@@ -868,10 +1116,14 @@ int test_notecard_sendRequest_does_not_modify_j_object_parameter_value_before_pa
     memcpy(json_cpy, EXPECTED_JSON, sizeof(J));
   } //assert(nullptr != (json_cpy = JDuplicate(EXPECTED_JSON,true)));
 
-  // Action
+   // Action
+  ///////////
+
   notecard.sendRequest(json_cpy);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (!memcmp(EXPECTED_JSON, noteRequest_Parameters.req, sizeof(J)) /*JCompare(EXPECTED_JSON, noteSendRequest_Parameters.req, false)*/)
   {
     result = 0;
@@ -879,7 +1131,7 @@ int test_notecard_sendRequest_does_not_modify_j_object_parameter_value_before_pa
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteRequest_Parameters.req != EXPECTED_JSON" << std::endl;
     std::cout << "[";
   }
@@ -893,17 +1145,23 @@ int test_notecard_sendRequest_does_not_modify_note_c_result_value_before_returni
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
   const bool EXPECTED_RESULT = true;
 
   noteRequest_Parameters.reset();
   noteRequest_Parameters.result = EXPECTED_RESULT;
 
-  // Action
+   // Action
+  ///////////
+
   const bool ACTUAL_RESULT = notecard.sendRequest(nullptr);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (EXPECTED_RESULT == ACTUAL_RESULT)
   {
     result = 0;
@@ -911,7 +1169,7 @@ int test_notecard_sendRequest_does_not_modify_note_c_result_value_before_returni
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnotecard.sendRequest(nullptr) == \"" << ACTUAL_RESULT << "\", EXPECTED: \"" << EXPECTED_RESULT << "\"" << std::endl;
     std::cout << "[";
   }
@@ -923,7 +1181,9 @@ int test_notecard_requestAndResponse_does_not_modify_j_object_parameter_value_be
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
   J *EXPECTED_JSON = reinterpret_cast<J *>(malloc(sizeof(J))); // JCreateObject();
   J *json_cpy;
@@ -937,10 +1197,14 @@ int test_notecard_requestAndResponse_does_not_modify_j_object_parameter_value_be
     memcpy(json_cpy, EXPECTED_JSON, sizeof(J));
   } //assert(nullptr != (json_cpy = JDuplicate(EXPECTED_JSON,true)));
 
-  // Action
+   // Action
+  ///////////
+
   notecard.requestAndResponse(json_cpy);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (!memcmp(EXPECTED_JSON, noteRequestResponse_Parameters.req, sizeof(J)) /*JCompare(EXPECTED_JSON, noteRequestResponse_Parameters.req, false)*/)
   {
     result = 0;
@@ -948,7 +1212,7 @@ int test_notecard_requestAndResponse_does_not_modify_j_object_parameter_value_be
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteRequestResponse_Parameters.req != EXPECTED_JSON" << std::endl;
     std::cout << "[";
   }
@@ -962,7 +1226,9 @@ int test_notecard_requestAndResponse_does_not_modify_note_c_result_value_before_
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
   J * EXPECTED_JSON = reinterpret_cast<J *>(malloc(sizeof(J))); // JCreateObject();
   assert(nullptr != EXPECTED_JSON);
@@ -975,10 +1241,14 @@ int test_notecard_requestAndResponse_does_not_modify_note_c_result_value_before_
     memcpy(noteRequestResponse_Parameters.result, EXPECTED_JSON, sizeof(J));
   } //assert(nullptr != (noteRequestResponse_Parameters.result = JDuplicate(EXPECTED_JSON,true)));
 
-  // Action
+   // Action
+  ///////////
+
   const J * const ACTUAL_RESULT = notecard.requestAndResponse(nullptr);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (!memcmp(EXPECTED_JSON, ACTUAL_RESULT, sizeof(J)) /*JCompare(EXPECTED_JSON, json_result, false)*/)
   {
     result = 0;
@@ -986,7 +1256,7 @@ int test_notecard_requestAndResponse_does_not_modify_note_c_result_value_before_
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnotecard.requestAndResponse(nullptr) != EXPECTED_JSON" << std::endl;
     std::cout << "[";
   }
@@ -1000,16 +1270,22 @@ int test_notecard_deleteResponse_does_not_modify_j_object_parameter_pointer_befo
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
   J *const EXPECTED_POINTER = reinterpret_cast<J *>(0x19790917);
 
   noteDeleteResponse_Parameters.reset();
 
-  // Action
+   // Action
+  ///////////
+
   notecard.deleteResponse(EXPECTED_POINTER);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (EXPECTED_POINTER == noteDeleteResponse_Parameters.response)
   {
     result = 0;
@@ -1017,7 +1293,7 @@ int test_notecard_deleteResponse_does_not_modify_j_object_parameter_pointer_befo
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteDeleteResponse_Parameters.response == " << std::hex << noteDeleteResponse_Parameters.response << ", EXPECTED: " << EXPECTED_POINTER << std::endl;
     std::cout << "[";
   }
@@ -1029,16 +1305,22 @@ int test_notecard_logDebug_does_not_modify_string_parameter_value_before_passing
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   const char str[] = "Hello, Test!";
   Notecard notecard;
 
   noteDebug_Parameters.reset();
 
-  // Action
+   // Action
+  ///////////
+
   notecard.logDebug(str);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (!strcmp(str, noteDebug_Parameters.message_cache.c_str()))
   {
     result = 0;
@@ -1046,7 +1328,7 @@ int test_notecard_logDebug_does_not_modify_string_parameter_value_before_passing
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteDebug_Parameters.message_cache.c_str() == \"" << noteDebug_Parameters.message_cache.c_str() << "\", EXPECTED: \"" << str << "\"" << std::endl;
     std::cout << "[";
   }
@@ -1058,16 +1340,22 @@ int test_notecard_logDebugf_does_not_modify_string_parameter_value_before_passin
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   const char str[] = "Hello, Test 123!";
   Notecard notecard;
 
   noteDebug_Parameters.reset();
 
-  // Action
+   // Action
+  ///////////
+
   notecard.logDebugf("Hello, %s %d%c", "Test", 123, '!');
 
-  // Assert
+   // Assert
+  ///////////
+
   if (!strcmp(str, noteDebug_Parameters.message_cache.c_str()))
   {
     result = 0;
@@ -1075,7 +1363,7 @@ int test_notecard_logDebugf_does_not_modify_string_parameter_value_before_passin
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteDebug_Parameters.message_cache.c_str() == \"" << noteDebug_Parameters.message_cache.c_str() << "\", EXPECTED: \"" << str << "\"" << std::endl;
     std::cout << "[";
   }
@@ -1087,16 +1375,22 @@ int test_notecard_debugSyncStatus_does_not_modify_pollFrequencyMs_parameter_befo
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
   const int EXPECTED_RESULT = 79;
 
   noteDebugSyncStatus_Parameters.reset();
 
-  // Action
+   // Action
+  ///////////
+
   notecard.debugSyncStatus(EXPECTED_RESULT, 0);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (EXPECTED_RESULT == noteDebugSyncStatus_Parameters.pollFrequencyMs)
   {
     result = 0;
@@ -1104,7 +1398,7 @@ int test_notecard_debugSyncStatus_does_not_modify_pollFrequencyMs_parameter_befo
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteDebugSyncStatus_Parameters.pollFrequencyMs == " << noteDebugSyncStatus_Parameters.pollFrequencyMs << ", EXPECTED: " << EXPECTED_RESULT << std::endl;
     std::cout << "[";
   }
@@ -1116,16 +1410,22 @@ int test_notecard_debugSyncStatus_does_not_modify_maxLevel_parameter_before_pass
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
   const int EXPECTED_RESULT = 79;
 
   noteDebugSyncStatus_Parameters.reset();
 
-  // Action
+   // Action
+  ///////////
+
   notecard.debugSyncStatus(0, EXPECTED_RESULT);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (EXPECTED_RESULT == noteDebugSyncStatus_Parameters.maxLevel)
   {
     result = 0;
@@ -1133,7 +1433,7 @@ int test_notecard_debugSyncStatus_does_not_modify_maxLevel_parameter_before_pass
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteDebugSyncStatus_Parameters.maxLevel == " << noteDebugSyncStatus_Parameters.maxLevel << ", EXPECTED: " << EXPECTED_RESULT << std::endl;
     std::cout << "[";
   }
@@ -1145,17 +1445,23 @@ int test_notecard_debugSyncStatus_does_not_modify_note_c_result_value_before_ret
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
   const bool EXPECTED_RESULT = true;
 
   noteDebugSyncStatus_Parameters.reset();
   noteDebugSyncStatus_Parameters.result = EXPECTED_RESULT;
 
-  // Action
+   // Action
+  ///////////
+
   const bool ACTUAL_RESULT = notecard.debugSyncStatus(0, 0);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (EXPECTED_RESULT == ACTUAL_RESULT)
   {
     result = 0;
@@ -1163,7 +1469,7 @@ int test_notecard_debugSyncStatus_does_not_modify_note_c_result_value_before_ret
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnotecard.debugSyncStatus(0, 0) == " << ACTUAL_RESULT << ", EXPECTED: " << EXPECTED_RESULT << std::endl;
     std::cout << "[";
   }
@@ -1175,7 +1481,9 @@ int test_notecard_responseError_does_not_modify_j_object_parameter_value_before_
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
   J * EXPECTED_JSON = reinterpret_cast<J *>(malloc(sizeof(J))); // JCreateObject();
   J * json_cpy;
@@ -1189,10 +1497,14 @@ int test_notecard_responseError_does_not_modify_j_object_parameter_value_before_
     memcpy(json_cpy, EXPECTED_JSON, sizeof(J));
   } //assert(nullptr != (json_cpy = JDuplicate(EXPECTED_JSON,true)));
 
-  // Action
+   // Action
+  ///////////
+
   notecard.responseError(json_cpy);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (!memcmp(EXPECTED_JSON, noteResponseError_Parameters.rsp, sizeof(J)) /*JCompare(EXPECTED_JSON, noteRequestResponse_Parameters.rsp, false)*/)
   {
     result = 0;
@@ -1200,7 +1512,7 @@ int test_notecard_responseError_does_not_modify_j_object_parameter_value_before_
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteResponseError_Parameters.rsp != EXPECTED_JSON" << std::endl;
     std::cout << "[";
   }
@@ -1214,17 +1526,23 @@ int test_notecard_responseError_does_not_modify_note_c_result_value_before_retur
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
   const bool EXPECTED_RESULT = true;
 
   noteResponseError_Parameters.reset();
   noteResponseError_Parameters.result = EXPECTED_RESULT;
 
-  // Action
+   // Action
+  ///////////
+
   const bool ACTUAL_RESULT = notecard.responseError(nullptr);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (EXPECTED_RESULT == ACTUAL_RESULT)
   {
     result = 0;
@@ -1232,7 +1550,7 @@ int test_notecard_responseError_does_not_modify_note_c_result_value_before_retur
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnotecard.responseError(nullptr) == " << ACTUAL_RESULT << ", EXPECTED: " << EXPECTED_RESULT << std::endl;
     std::cout << "[";
   }
@@ -1244,16 +1562,22 @@ int test_notecard_newCommand_does_not_modify_string_parameter_value_before_passi
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
   const char EXPECTED_RESULT[] = "Hello, Test!";
 
   noteNewCommand_Parameters.reset();
 
-  // Action
+   // Action
+  ///////////
+
   notecard.newCommand(EXPECTED_RESULT);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (!strcmp(EXPECTED_RESULT, noteNewCommand_Parameters.request_cache.c_str()))
   {
     result = 0;
@@ -1261,7 +1585,7 @@ int test_notecard_newCommand_does_not_modify_string_parameter_value_before_passi
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteNewCommand_Parameters.request_cache.c_str() == \"" << noteNewCommand_Parameters.request_cache.c_str() << "\", EXPECTED: \"" << EXPECTED_RESULT << "\"" << std::endl;
     std::cout << "[";
   }
@@ -1273,7 +1597,9 @@ int test_notecard_newCommand_does_not_modify_note_c_result_value_before_returnin
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
   J * EXPECTED_JSON = reinterpret_cast<J *>(malloc(sizeof(J))); // JCreateObject();
   assert(nullptr != EXPECTED_JSON);
@@ -1286,10 +1612,14 @@ int test_notecard_newCommand_does_not_modify_note_c_result_value_before_returnin
     memcpy(noteNewCommand_Parameters.result, EXPECTED_JSON, sizeof(J));
   } //assert(nullptr != (noteNewCommand_Parameters.result = JDuplicate(EXPECTED_JSON,true)));
 
-  // Action
+   // Action
+  ///////////
+
   const J * const ACTUAL_RESULT = notecard.newCommand(nullptr);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (!memcmp(EXPECTED_JSON, ACTUAL_RESULT, sizeof(J)) /*JCompare(EXPECTED_JSON, ACTUAL_RESULT, false)*/)
   {
     result = 0;
@@ -1297,7 +1627,7 @@ int test_notecard_newCommand_does_not_modify_note_c_result_value_before_returnin
   else
   {
     result = static_cast<int>('n' + 'o' + 't' + 'e' + 'c' + 'a' + 'r' + 'd');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnotecard.newCommand(nullptr) != EXPECTED_JSON" << std::endl;
     std::cout << "[";
   }
@@ -1311,7 +1641,9 @@ int test_static_callback_note_i2c_receive_invokes_notei2c_receive()
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   const uint16_t ADDRESS = 0x17;
   const uint16_t SIZE = 13;
   uint8_t response_buffer[32];
@@ -1324,10 +1656,14 @@ int test_static_callback_note_i2c_receive_invokes_notei2c_receive()
   notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
   noteI2cReceive_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   noteSetFnI2C_Parameters.receivefn(ADDRESS, response_buffer, SIZE, &actual_response_size);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (noteI2cReceive_Parameters.invoked)
   {
     result = 0;
@@ -1335,7 +1671,7 @@ int test_static_callback_note_i2c_receive_invokes_notei2c_receive()
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteI2cReceive_Parameters.invoked == " << noteI2cReceive_Parameters.invoked << ", EXPECTED: > 0" << std::endl;
     std::cout << "[";
   }
@@ -1347,7 +1683,9 @@ int test_static_callback_note_i2c_receive_does_not_modify_device_address_paramet
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   // 0x1B binary representation => 0001 1011
   const uint16_t EXPECTED_ADDRESS = 0x1B;
   const uint16_t SIZE = 13;
@@ -1361,10 +1699,14 @@ int test_static_callback_note_i2c_receive_does_not_modify_device_address_paramet
   notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
   noteI2cReceive_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   noteSetFnI2C_Parameters.receivefn(EXPECTED_ADDRESS, response_buffer, SIZE, &actual_response_size);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (EXPECTED_ADDRESS == noteI2cReceive_Parameters.device_address)
   {
     result = 0;
@@ -1372,7 +1714,7 @@ int test_static_callback_note_i2c_receive_does_not_modify_device_address_paramet
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteI2cReceive_Parameters.device_address == " << noteI2cReceive_Parameters.device_address << ", EXPECTED: " << EXPECTED_ADDRESS << std::endl;
     std::cout << "[";
   }
@@ -1384,7 +1726,9 @@ int test_static_callback_note_i2c_receive_does_not_modify_buffer_parameter_addre
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   const uint16_t ADDRESS = 0x1B;
   const uint16_t SIZE = 13;
   uint8_t response_buffer[32];
@@ -1397,10 +1741,14 @@ int test_static_callback_note_i2c_receive_does_not_modify_buffer_parameter_addre
   notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
   noteI2cReceive_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   noteSetFnI2C_Parameters.receivefn(ADDRESS, response_buffer, SIZE, &actual_response_size);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (response_buffer == noteI2cReceive_Parameters.buffer)
   {
     result = 0;
@@ -1408,7 +1756,7 @@ int test_static_callback_note_i2c_receive_does_not_modify_buffer_parameter_addre
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << std::hex << "\tnoteI2cReceive_Parameters.buffer == " << noteI2cReceive_Parameters.buffer << ", EXPECTED: " << &response_buffer[0] << std::endl;
     std::cout << "[";
   }
@@ -1420,7 +1768,9 @@ int test_static_callback_note_i2c_receive_does_not_modify_size_parameter_before_
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   const uint16_t ADDRESS = 0x1B;
   const uint16_t EXPECTED_SIZE = 13;
   uint8_t response_buffer[32];
@@ -1433,10 +1783,14 @@ int test_static_callback_note_i2c_receive_does_not_modify_size_parameter_before_
   notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
   noteI2cReceive_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   noteSetFnI2C_Parameters.receivefn(ADDRESS, response_buffer, EXPECTED_SIZE, &actual_response_size);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (EXPECTED_SIZE == noteI2cReceive_Parameters.requested_byte_count)
   {
     result = 0;
@@ -1444,7 +1798,7 @@ int test_static_callback_note_i2c_receive_does_not_modify_size_parameter_before_
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteI2cReceive_Parameters.requested_byte_count == " << noteI2cReceive_Parameters.requested_byte_count << ", EXPECTED: " << EXPECTED_SIZE << std::endl;
     std::cout << "[";
   }
@@ -1456,7 +1810,9 @@ int test_static_callback_note_i2c_receive_does_not_modify_available_parameter_ad
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   const uint16_t ADDRESS = 0x1B;
   const uint16_t SIZE = 13;
   uint8_t response_buffer[32];
@@ -1469,10 +1825,14 @@ int test_static_callback_note_i2c_receive_does_not_modify_available_parameter_ad
   notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
   noteI2cReceive_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   noteSetFnI2C_Parameters.receivefn(ADDRESS, response_buffer, SIZE, &actual_response_size);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (&actual_response_size == noteI2cReceive_Parameters.available)
   {
     result = 0;
@@ -1480,7 +1840,7 @@ int test_static_callback_note_i2c_receive_does_not_modify_available_parameter_ad
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << std::hex << "\tnoteI2cReceive_Parameters.available == " << noteI2cReceive_Parameters.available << ", EXPECTED: " << &actual_response_size << std::endl;
     std::cout << "[";
   }
@@ -1492,7 +1852,9 @@ int test_static_callback_note_i2c_receive_does_not_modify_interface_method_retur
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   const uint16_t ADDRESS = 0x1B;
   const uint16_t SIZE = 13;
   uint8_t response_buffer[32];
@@ -1506,10 +1868,14 @@ int test_static_callback_note_i2c_receive_does_not_modify_interface_method_retur
   noteI2cReceive_Parameters.reset();  // Clear the structure for testing results
   noteI2cReceive_Parameters.result = "i2c: fake test error!";
 
-  // Action
+   // Action
+  ///////////
+
   const char * const ACTUAL_RESULT = noteSetFnI2C_Parameters.receivefn(ADDRESS, response_buffer, SIZE, &actual_response_size);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (!strcmp(ACTUAL_RESULT, noteI2cReceive_Parameters.result))
   {
     result = 0;
@@ -1517,7 +1883,7 @@ int test_static_callback_note_i2c_receive_does_not_modify_interface_method_retur
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tACTUAL_RESULT == " << ACTUAL_RESULT << ", EXPECTED: " << noteI2cReceive_Parameters.result << std::endl;
     std::cout << "[";
   }
@@ -1529,7 +1895,9 @@ int test_static_callback_note_i2c_receive_does_not_call_interface_method_when_in
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   const uint16_t ADDRESS = 0x1B;
   const uint16_t SIZE = 13;
   uint8_t response_buffer[32];
@@ -1540,10 +1908,14 @@ int test_static_callback_note_i2c_receive_does_not_call_interface_method_when_in
   notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
   noteI2cReceive_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   noteSetFnI2C_Parameters.receivefn(ADDRESS, response_buffer, SIZE, &actual_response_size);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (!noteI2cReceive_Parameters.invoked)
   {
     result = 0;
@@ -1551,7 +1923,7 @@ int test_static_callback_note_i2c_receive_does_not_call_interface_method_when_in
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteI2cReceive_Parameters.invoked == " << noteI2cReceive_Parameters.invoked << ", EXPECTED: zero (0)" << std::endl;
     std::cout << "[";
   }
@@ -1563,7 +1935,9 @@ int test_static_callback_note_i2c_receive_returns_error_message_when_interface_h
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   const uint16_t ADDRESS = 0x1B;
   const uint16_t SIZE = 13;
   uint8_t response_buffer[32];
@@ -1575,10 +1949,14 @@ int test_static_callback_note_i2c_receive_returns_error_message_when_interface_h
   notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
   noteI2cReceive_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   const char * const ACTUAL_RESULT = noteSetFnI2C_Parameters.receivefn(ADDRESS, response_buffer, SIZE, &actual_response_size);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (!strcmp(ACTUAL_RESULT,EXPECTED_RESULT))
   {
     result = 0;
@@ -1586,7 +1964,7 @@ int test_static_callback_note_i2c_receive_returns_error_message_when_interface_h
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tACTUAL_RESULT == " << ACTUAL_RESULT << ", EXPECTED: " << EXPECTED_RESULT << std::endl;
     std::cout << "[";
   }
@@ -1598,7 +1976,9 @@ int test_static_callback_note_i2c_reset_invokes_notei2c_reset()
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   const uint16_t ADDRESS = 0x17;
 
   Notecard notecard;
@@ -1608,10 +1988,14 @@ int test_static_callback_note_i2c_reset_invokes_notei2c_reset()
   notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
   noteI2cReset_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   noteSetFnI2C_Parameters.resetfn(ADDRESS);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (noteI2cReset_Parameters.invoked)
   {
     result = 0;
@@ -1619,7 +2003,7 @@ int test_static_callback_note_i2c_reset_invokes_notei2c_reset()
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteI2cReset_Parameters.invoked == " << noteI2cReset_Parameters.invoked << ", EXPECTED: > 0" << std::endl;
     std::cout << "[";
   }
@@ -1631,7 +2015,9 @@ int test_static_callback_note_i2c_reset_does_not_modify_device_address_parameter
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   // 0x1B binary representation => 0001 1011
   const uint16_t EXPECTED_ADDRESS = 0x1B;
 
@@ -1642,10 +2028,14 @@ int test_static_callback_note_i2c_reset_does_not_modify_device_address_parameter
   notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
   noteI2cReset_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   noteSetFnI2C_Parameters.resetfn(EXPECTED_ADDRESS);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (EXPECTED_ADDRESS == noteI2cReset_Parameters.device_address)
   {
     result = 0;
@@ -1653,7 +2043,7 @@ int test_static_callback_note_i2c_reset_does_not_modify_device_address_parameter
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteI2cReset_Parameters.device_address == " << noteI2cReset_Parameters.device_address << ", EXPECTED: " << EXPECTED_ADDRESS << std::endl;
     std::cout << "[";
   }
@@ -1665,7 +2055,9 @@ int test_static_callback_note_i2c_reset_does_not_modify_interface_method_return_
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   const uint16_t ADDRESS = 0x1B;
 
   Notecard notecard;
@@ -1676,10 +2068,14 @@ int test_static_callback_note_i2c_reset_does_not_modify_interface_method_return_
   noteI2cReset_Parameters.reset();  // Clear the structure for testing results
   noteI2cReset_Parameters.result = true;
 
-  // Action
+   // Action
+  ///////////
+
   const bool ACTUAL_RESULT = noteSetFnI2C_Parameters.resetfn(ADDRESS);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (ACTUAL_RESULT == noteI2cReset_Parameters.result)
   {
     result = 0;
@@ -1687,7 +2083,7 @@ int test_static_callback_note_i2c_reset_does_not_modify_interface_method_return_
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tACTUAL_RESULT == " << ACTUAL_RESULT << ", EXPECTED: " << noteI2cReset_Parameters.result << std::endl;
     std::cout << "[";
   }
@@ -1699,7 +2095,9 @@ int test_static_callback_note_i2c_reset_does_not_call_interface_method_when_inte
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   const uint16_t ADDRESS = 0x1B;
 
   Notecard notecard;
@@ -1707,10 +2105,14 @@ int test_static_callback_note_i2c_reset_does_not_call_interface_method_when_inte
   notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
   noteI2cReset_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   noteSetFnI2C_Parameters.resetfn(ADDRESS);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (!noteI2cReset_Parameters.invoked)
   {
     result = 0;
@@ -1718,7 +2120,7 @@ int test_static_callback_note_i2c_reset_does_not_call_interface_method_when_inte
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteI2cReset_Parameters.invoked == " << noteI2cReset_Parameters.invoked << ", EXPECTED: zero (0)" << std::endl;
     std::cout << "[";
   }
@@ -1730,7 +2132,9 @@ int test_static_callback_note_i2c_reset_returns_false_when_interface_has_not_bee
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   const uint16_t ADDRESS = 0x1B;
 
   Notecard notecard;
@@ -1738,10 +2142,14 @@ int test_static_callback_note_i2c_reset_returns_false_when_interface_has_not_bee
   notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
   noteI2cReset_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   const bool ACTUAL_RESULT = noteSetFnI2C_Parameters.resetfn(ADDRESS);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (!ACTUAL_RESULT)
   {
     result = 0;
@@ -1749,7 +2157,7 @@ int test_static_callback_note_i2c_reset_returns_false_when_interface_has_not_bee
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tACTUAL_RESULT == " << ACTUAL_RESULT << ", EXPECTED: false (0)" << std::endl;
     std::cout << "[";
   }
@@ -1761,7 +2169,9 @@ int test_static_callback_note_i2c_transmit_invokes_notei2c_transmit()
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   const uint16_t ADDRESS = 0x17;
   const uint16_t SIZE = 13;
   uint8_t transmit_buffer[32];
@@ -1773,10 +2183,14 @@ int test_static_callback_note_i2c_transmit_invokes_notei2c_transmit()
   notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
   noteI2cTransmit_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   noteSetFnI2C_Parameters.transmitfn(ADDRESS, transmit_buffer, SIZE);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (noteI2cTransmit_Parameters.invoked)
   {
     result = 0;
@@ -1784,7 +2198,7 @@ int test_static_callback_note_i2c_transmit_invokes_notei2c_transmit()
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteI2cTransmit_Parameters.invoked == " << noteI2cTransmit_Parameters.invoked << ", EXPECTED: > 0" << std::endl;
     std::cout << "[";
   }
@@ -1796,7 +2210,9 @@ int test_static_callback_note_i2c_transmit_does_not_modify_device_address_parame
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   // 0x1B binary representation => 0001 1011
   const uint16_t EXPECTED_ADDRESS = 0x1B;
   const uint16_t SIZE = 13;
@@ -1809,10 +2225,14 @@ int test_static_callback_note_i2c_transmit_does_not_modify_device_address_parame
   notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
   noteI2cTransmit_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   noteSetFnI2C_Parameters.transmitfn(EXPECTED_ADDRESS, transmit_buffer, SIZE);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (EXPECTED_ADDRESS == noteI2cTransmit_Parameters.device_address)
   {
     result = 0;
@@ -1820,7 +2240,7 @@ int test_static_callback_note_i2c_transmit_does_not_modify_device_address_parame
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteI2cTransmit_Parameters.device_address == " << noteI2cTransmit_Parameters.device_address << ", EXPECTED: " << EXPECTED_ADDRESS << std::endl;
     std::cout << "[";
   }
@@ -1832,7 +2252,9 @@ int test_static_callback_note_i2c_transmit_does_not_modify_buffer_parameter_befo
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   const uint16_t ADDRESS = 0x1B;
   const uint16_t SIZE = 13;
   uint8_t transmit_buffer[] = "Test Passed!";
@@ -1844,10 +2266,14 @@ int test_static_callback_note_i2c_transmit_does_not_modify_buffer_parameter_befo
   notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
   noteI2cTransmit_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   noteSetFnI2C_Parameters.transmitfn(ADDRESS, transmit_buffer, SIZE);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (!strcmp(reinterpret_cast<char *>(transmit_buffer),reinterpret_cast<char *>(noteI2cTransmit_Parameters.buffer)))
   {
     result = 0;
@@ -1855,7 +2281,7 @@ int test_static_callback_note_i2c_transmit_does_not_modify_buffer_parameter_befo
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteI2cTransmit_Parameters.buffer == " << noteI2cTransmit_Parameters.buffer << ", EXPECTED: " << transmit_buffer << std::endl;
     std::cout << "[";
   }
@@ -1867,7 +2293,9 @@ int test_static_callback_note_i2c_transmit_does_not_modify_size_parameter_before
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   const uint16_t ADDRESS = 0x1B;
   const uint16_t EXPECTED_SIZE = 13;
   uint8_t transmit_buffer[32];
@@ -1879,10 +2307,14 @@ int test_static_callback_note_i2c_transmit_does_not_modify_size_parameter_before
   notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
   noteI2cTransmit_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   noteSetFnI2C_Parameters.transmitfn(ADDRESS, transmit_buffer, EXPECTED_SIZE);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (EXPECTED_SIZE == noteI2cTransmit_Parameters.size)
   {
     result = 0;
@@ -1890,7 +2322,7 @@ int test_static_callback_note_i2c_transmit_does_not_modify_size_parameter_before
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteI2cTransmit_Parameters.size == " << noteI2cTransmit_Parameters.size << ", EXPECTED: " << EXPECTED_SIZE << std::endl;
     std::cout << "[";
   }
@@ -1902,7 +2334,9 @@ int test_static_callback_note_i2c_transmit_does_not_modify_interface_method_retu
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   const uint16_t ADDRESS = 0x1B;
   const uint16_t SIZE = 13;
   uint8_t transmit_buffer[32];
@@ -1915,10 +2349,14 @@ int test_static_callback_note_i2c_transmit_does_not_modify_interface_method_retu
   noteI2cTransmit_Parameters.reset();  // Clear the structure for testing results
   noteI2cTransmit_Parameters.result = "i2c: fake test error!";
 
-  // Action
+   // Action
+  ///////////
+
   const char * const ACTUAL_RESULT = noteSetFnI2C_Parameters.transmitfn(ADDRESS, transmit_buffer, SIZE);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (!strcmp(ACTUAL_RESULT, noteI2cTransmit_Parameters.result))
   {
     result = 0;
@@ -1926,7 +2364,7 @@ int test_static_callback_note_i2c_transmit_does_not_modify_interface_method_retu
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tACTUAL_RESULT == " << ACTUAL_RESULT << ", EXPECTED: " << noteI2cTransmit_Parameters.result << std::endl;
     std::cout << "[";
   }
@@ -1938,7 +2376,9 @@ int test_static_callback_note_i2c_transmit_does_not_call_interface_method_when_i
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   const uint16_t ADDRESS = 0x1B;
   const uint16_t SIZE = 13;
   uint8_t transmit_buffer[32];
@@ -1948,10 +2388,14 @@ int test_static_callback_note_i2c_transmit_does_not_call_interface_method_when_i
   notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
   noteI2cTransmit_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   noteSetFnI2C_Parameters.transmitfn(ADDRESS, transmit_buffer, SIZE);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (!noteI2cTransmit_Parameters.invoked)
   {
     result = 0;
@@ -1959,7 +2403,7 @@ int test_static_callback_note_i2c_transmit_does_not_call_interface_method_when_i
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteI2cTransmit_Parameters == " << noteI2cTransmit_Parameters.invoked << ", EXPECTED: zero (0)" << std::endl;
     std::cout << "[";
   }
@@ -1971,7 +2415,9 @@ int test_static_callback_note_i2c_transmit_returns_error_message_when_interface_
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   const uint16_t ADDRESS = 0x1B;
   const uint16_t SIZE = 13;
   uint8_t transmit_buffer[32];
@@ -1982,10 +2428,14 @@ int test_static_callback_note_i2c_transmit_returns_error_message_when_interface_
   notecard.begin();  // Provides access to the hidden static callback methods through `note-c` mocks
   noteI2cTransmit_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   const char * const ACTUAL_RESULT = noteSetFnI2C_Parameters.transmitfn(ADDRESS, transmit_buffer, SIZE);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (!strcmp(ACTUAL_RESULT,EXPECTED_RESULT))
   {
     result = 0;
@@ -1993,7 +2443,7 @@ int test_static_callback_note_i2c_transmit_returns_error_message_when_interface_
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tACTUAL_RESULT == " << ACTUAL_RESULT << ", EXPECTED: " << EXPECTED_RESULT << std::endl;
     std::cout << "[";
   }
@@ -2005,20 +2455,27 @@ int test_static_callback_note_log_print_invokes_notelog_print()
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   const char message[] = "Test passed!";
 
   Notecard notecard;
-  NoteLog_Arduino mockLog_arduino(&Serial);  // Instantiate NoteLog (mocked)
+  NoteLog_Mock mockLog;  // Instantiate NoteLog (mocked)
   make_note_log_Parameters.reset();
-  make_note_log_Parameters.result = &mockLog_arduino;  // Return mocked interface
-  notecard.setDebugOutputStream(Serial);  // Provides access to the hidden static callback methods through `note-c` mocks
-  noteLogPrint_Parameters.reset();  // Clear the structure for testing results
+  make_note_log_Parameters.result = &mockLog;  // Return mocked interface
+  notecard.setDebugOutputStream(&result);  // Provides access to the hidden static callback methods through `note-c` mocks
+  size_t(*noteLogPrint)(const char *) = noteSetFnDebugOutput_Parameters.fn;  // Capture the internal Notecard log function, `noteLogPrint`
+  noteLogPrint_Parameters.reset();  // Clear the structure for testing NoteLog::print results
 
-  // Action
-  noteSetFnDebugOutput_Parameters.fn(message);
+   // Action
+  ///////////
 
-  // Assert
+  noteLogPrint(message);
+
+   // Assert
+  ///////////
+
   if (noteLogPrint_Parameters.invoked)
   {
     result = 0;
@@ -2026,7 +2483,7 @@ int test_static_callback_note_log_print_invokes_notelog_print()
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteLogPrint_Parameters.invoked == " << noteLogPrint_Parameters.invoked << ", EXPECTED: > 0" << std::endl;
     std::cout << "[";
   }
@@ -2038,20 +2495,27 @@ int test_static_callback_note_log_print_does_not_modify_message_parameter_before
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   const char message[] = "Test passed!";
 
   Notecard notecard;
-  NoteLog_Arduino mockLog_arduino(&Serial);  // Instantiate NoteLog (mocked)
+  NoteLog_Mock mockLog;  // Instantiate NoteLog (mocked)
   make_note_log_Parameters.reset();
-  make_note_log_Parameters.result = &mockLog_arduino;  // Return mocked interface
-  notecard.setDebugOutputStream(Serial);  // Provides access to the hidden static callback methods through `note-c` mocks
-  noteLogPrint_Parameters.reset();  // Clear the structure for testing results
+  make_note_log_Parameters.result = &mockLog;  // Return mocked interface
+  notecard.setDebugOutputStream(&result);  // Provides access to the hidden static callback methods through `note-c` mocks
+  size_t(*noteLogPrint)(const char *) = noteSetFnDebugOutput_Parameters.fn;  // Capture the internal Notecard log function, `noteLogPrint`
+  noteLogPrint_Parameters.reset();  // Clear the structure for testing NoteLog::print results
 
-  // Action
-  noteSetFnDebugOutput_Parameters.fn(message);
+   // Action
+  ///////////
 
-  // Assert
+  noteLogPrint(message);
+
+   // Assert
+  ///////////
+
   if (!strcmp(message, noteLogPrint_Parameters.message))
   {
     result = 0;
@@ -2059,7 +2523,7 @@ int test_static_callback_note_log_print_does_not_modify_message_parameter_before
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteLogPrint_Parameters.message == " << noteLogPrint_Parameters.message << ", EXPECTED: " << message << std::endl;
     std::cout << "[";
   }
@@ -2071,21 +2535,28 @@ int test_static_callback_note_log_print_does_not_modify_interface_method_return_
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   const char message[] = "Test passed!";
 
   Notecard notecard;
-  NoteLog_Arduino mockLog_arduino(&Serial);  // Instantiate NoteLog (mocked)
+  NoteLog_Mock mockLog;  // Instantiate NoteLog (mocked)
   make_note_log_Parameters.reset();
-  make_note_log_Parameters.result = &mockLog_arduino;  // Return mocked interface
-  notecard.setDebugOutputStream(Serial);  // Provides access to the hidden static callback methods through `note-c` mocks
-  noteLogPrint_Parameters.reset();  // Clear the structure for testing results
+  make_note_log_Parameters.result = &mockLog;  // Return mocked interface
+  notecard.setDebugOutputStream(&result);  // Provides access to the hidden static callback methods through `note-c` mocks
+  size_t(*noteLogPrint)(const char *) = noteSetFnDebugOutput_Parameters.fn;  // Capture the internal Notecard log function, `noteLogPrint`
+  noteLogPrint_Parameters.reset();  // Clear the structure for testing NoteLog::print results
   noteLogPrint_Parameters.result = sizeof(message);
 
-  // Action
-  const size_t ACTUAL_RESULT = noteSetFnDebugOutput_Parameters.fn(message);
+   // Action
+  ///////////
 
-  // Assert
+  const size_t ACTUAL_RESULT = noteLogPrint(message);
+
+   // Assert
+  ///////////
+
   if (ACTUAL_RESULT == noteLogPrint_Parameters.result)
   {
     result = 0;
@@ -2093,7 +2564,7 @@ int test_static_callback_note_log_print_does_not_modify_interface_method_return_
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tACTUAL_RESULT == " << ACTUAL_RESULT << ", EXPECTED: " << noteLogPrint_Parameters.result << std::endl;
     std::cout << "[";
   }
@@ -2105,18 +2576,32 @@ int test_static_callback_note_log_print_does_not_call_interface_method_when_inte
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   const char message[] = "Test passed!";
 
   Notecard notecard;
+
+  // Capture the internal Notecard log function, `noteLogPrint`
   make_note_log_Parameters.reset();
-  notecard.setDebugOutputStream(Serial);  // Provides access to the hidden static callback methods through `note-c` mocks
-  noteLogPrint_Parameters.reset();  // Clear the structure for testing results
+  make_note_log_Parameters.result = reinterpret_cast<NoteLog *>(&result);
+  notecard.setDebugOutputStream(&result);  // Provides access to the internal static callback methods through `note-c` mocks
+  size_t(*noteLogPrint)(const char *) = noteSetFnDebugOutput_Parameters.fn;
 
-  // Action
-  noteSetFnDebugOutput_Parameters.fn(message);
+  // Ensure interface is not instantiated
+  make_note_log_Parameters.reset();
+  notecard.setDebugOutputStream(nullptr);  // Provides access to the hidden static callback methods through `note-c` mocks
+  noteLogPrint_Parameters.reset();  // Clear the structure for testing NoteLog::print results
 
-  // Assert
+   // Action
+  ///////////
+
+  noteLogPrint(message);
+
+   // Assert
+  ///////////
+
   if (!noteLogPrint_Parameters.invoked)
   {
     result = 0;
@@ -2124,7 +2609,7 @@ int test_static_callback_note_log_print_does_not_call_interface_method_when_inte
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteLogPrint_Parameters.invoked == " << noteLogPrint_Parameters.invoked << ", EXPECTED: zero (0)" << std::endl;
     std::cout << "[";
   }
@@ -2136,18 +2621,32 @@ int test_static_callback_note_log_print_returns_false_when_interface_has_not_bee
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   const char message[] = "Test passed!";
 
   Notecard notecard;
+
+  // Capture the internal Notecard log function, `noteLogPrint`
   make_note_log_Parameters.reset();
-  notecard.setDebugOutputStream(Serial);  // Provides access to the hidden static callback methods through `note-c` mocks
-  noteLogPrint_Parameters.reset();  // Clear the structure for testing results
+  make_note_log_Parameters.result = reinterpret_cast<NoteLog *>(&result);
+  notecard.setDebugOutputStream(&result);  // Provides access to the internal static callback methods through `note-c` mocks
+  size_t(*noteLogPrint)(const char *) = noteSetFnDebugOutput_Parameters.fn;
 
-  // Action
-  const size_t ACTUAL_RESULT = noteSetFnDebugOutput_Parameters.fn(message);
+  // Ensure interface is not instantiated
+  make_note_log_Parameters.reset();
+  notecard.setDebugOutputStream(&result);  // Provides access to the hidden static callback methods through `note-c` mocks
+  noteLogPrint_Parameters.reset();  // Clear the structure for testing NoteLog::print results
 
-  // Assert
+   // Action
+  ///////////
+
+  const size_t ACTUAL_RESULT = noteLogPrint(message);
+
+   // Assert
+  ///////////
+
   if (!ACTUAL_RESULT)
   {
     result = 0;
@@ -2155,7 +2654,7 @@ int test_static_callback_note_log_print_returns_false_when_interface_has_not_bee
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tACTUAL_RESULT == " << ACTUAL_RESULT << ", EXPECTED: zero (0)" << std::endl;
     std::cout << "[";
   }
@@ -2167,7 +2666,9 @@ int test_static_callback_note_serial_available_invokes_noteserial_available()
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
   NoteSerial_Arduino mockSerial_arduino(Serial,9600);  // Instantiate NoteSerial (mocked)
   make_note_serial_Parameters.reset();
@@ -2175,10 +2676,14 @@ int test_static_callback_note_serial_available_invokes_noteserial_available()
   notecard.begin(Serial);  // Provides access to the hidden static callback methods through `note-c` mocks
   noteSerialAvailable_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   noteSetFnSerial_Parameters.availfn();
 
-  // Assert
+   // Assert
+  ///////////
+
   if (noteSerialAvailable_Parameters.invoked)
   {
     result = 0;
@@ -2186,7 +2691,7 @@ int test_static_callback_note_serial_available_invokes_noteserial_available()
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteSerialAvailable_Parameters.invoked == " << noteSerialAvailable_Parameters.invoked << ", EXPECTED: > 0" << std::endl;
     std::cout << "[";
   }
@@ -2198,7 +2703,9 @@ int test_static_callback_note_serial_available_does_not_modify_interface_method_
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
   NoteSerial_Arduino mockSerial_arduino(Serial,9600);  // Instantiate NoteSerial (mocked)
   make_note_serial_Parameters.reset();
@@ -2207,10 +2714,14 @@ int test_static_callback_note_serial_available_does_not_modify_interface_method_
   noteSerialAvailable_Parameters.reset();  // Clear the structure for testing results
   noteSerialAvailable_Parameters.result = true;
 
-  // Action
+   // Action
+  ///////////
+
   const bool ACTUAL_RESULT = noteSetFnSerial_Parameters.availfn();
 
-  // Assert
+   // Assert
+  ///////////
+
   if (ACTUAL_RESULT == noteSerialAvailable_Parameters.result)
   {
     result = 0;
@@ -2218,7 +2729,7 @@ int test_static_callback_note_serial_available_does_not_modify_interface_method_
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tACTUAL_RESULT == " << ACTUAL_RESULT << ", EXPECTED: " << noteSerialAvailable_Parameters.result << std::endl;
     std::cout << "[";
   }
@@ -2230,16 +2741,22 @@ int test_static_callback_note_serial_available_does_not_call_interface_method_wh
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
   make_note_serial_Parameters.reset();
   notecard.begin(Serial);  // Provides access to the hidden static callback methods through `note-c` mocks
   noteSerialAvailable_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   noteSetFnSerial_Parameters.availfn();
 
-  // Assert
+   // Assert
+  ///////////
+
   if (!noteSerialAvailable_Parameters.invoked)
   {
     result = 0;
@@ -2247,7 +2764,7 @@ int test_static_callback_note_serial_available_does_not_call_interface_method_wh
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteSerialAvailable_Parameters.invoked == " << noteSerialAvailable_Parameters.invoked << ", EXPECTED: zero (0)" << std::endl;
     std::cout << "[";
   }
@@ -2259,16 +2776,22 @@ int test_static_callback_note_serial_available_returns_false_when_interface_has_
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
   make_note_serial_Parameters.reset();
   notecard.begin(Serial);  // Provides access to the hidden static callback methods through `note-c` mocks
   noteSerialAvailable_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   const bool ACTUAL_RESULT = noteSetFnSerial_Parameters.availfn();
 
-  // Assert
+   // Assert
+  ///////////
+
   if (!ACTUAL_RESULT)
   {
     result = 0;
@@ -2276,7 +2799,7 @@ int test_static_callback_note_serial_available_returns_false_when_interface_has_
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tACTUAL_RESULT == " << ACTUAL_RESULT << ", EXPECTED: false (0)" << std::endl;
     std::cout << "[";
   }
@@ -2288,7 +2811,9 @@ int test_static_callback_note_serial_receive_invokes_noteserial_receive()
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
   NoteSerial_Arduino mockSerial_arduino(Serial,9600);  // Instantiate NoteSerial (mocked)
   make_note_serial_Parameters.reset();
@@ -2296,10 +2821,14 @@ int test_static_callback_note_serial_receive_invokes_noteserial_receive()
   notecard.begin(Serial);  // Provides access to the hidden static callback methods through `note-c` mocks
   noteSerialReceive_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   noteSetFnSerial_Parameters.readfn();
 
-  // Assert
+   // Assert
+  ///////////
+
   if (noteSerialReceive_Parameters.invoked)
   {
     result = 0;
@@ -2307,7 +2836,7 @@ int test_static_callback_note_serial_receive_invokes_noteserial_receive()
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteSerialReceive_Parameters.invoked == " << noteSerialReceive_Parameters.invoked << ", EXPECTED: > 0" << std::endl;
     std::cout << "[";
   }
@@ -2319,7 +2848,9 @@ int test_static_callback_note_serial_receive_does_not_modify_interface_method_re
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
   NoteSerial_Arduino mockSerial_arduino(Serial,9600);  // Instantiate NoteSerial (mocked)
   make_note_serial_Parameters.reset();
@@ -2328,10 +2859,14 @@ int test_static_callback_note_serial_receive_does_not_modify_interface_method_re
   noteSerialReceive_Parameters.reset();  // Clear the structure for testing results
   noteSerialReceive_Parameters.result = 'Z';
 
-  // Action
+   // Action
+  ///////////
+
   const char ACTUAL_RESULT = noteSetFnSerial_Parameters.readfn();
 
-  // Assert
+   // Assert
+  ///////////
+
   if (ACTUAL_RESULT == noteSerialReceive_Parameters.result)
   {
     result = 0;
@@ -2339,7 +2874,7 @@ int test_static_callback_note_serial_receive_does_not_modify_interface_method_re
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tACTUAL_RESULT == " << ACTUAL_RESULT << ", EXPECTED: " << noteSerialReceive_Parameters.result << std::endl;
     std::cout << "[";
   }
@@ -2351,16 +2886,22 @@ int test_static_callback_note_serial_receive_does_not_call_interface_method_when
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
   make_note_serial_Parameters.reset();
   notecard.begin(Serial);  // Provides access to the hidden static callback methods through `note-c` mocks
   noteSerialReceive_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   noteSetFnSerial_Parameters.readfn();
 
-  // Assert
+   // Assert
+  ///////////
+
   if (!noteSerialReceive_Parameters.invoked)
   {
     result = 0;
@@ -2368,7 +2909,7 @@ int test_static_callback_note_serial_receive_does_not_call_interface_method_when
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteSerialReceive_Parameters.invoked == " << noteSerialReceive_Parameters.invoked << ", EXPECTED: zero (0)" << std::endl;
     std::cout << "[";
   }
@@ -2380,17 +2921,23 @@ int test_static_callback_note_serial_receive_returns_false_when_interface_has_no
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   const char EXPECTED_RESULT = '\0';
   Notecard notecard;
   make_note_serial_Parameters.reset();
   notecard.begin(Serial);  // Provides access to the hidden static callback methods through `note-c` mocks
   noteSerialReceive_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   const char ACTUAL_RESULT = noteSetFnSerial_Parameters.readfn();
 
-  // Assert
+   // Assert
+  ///////////
+
   if (ACTUAL_RESULT == EXPECTED_RESULT)
   {
     result = 0;
@@ -2398,7 +2945,7 @@ int test_static_callback_note_serial_receive_returns_false_when_interface_has_no
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tACTUAL_RESULT == " << ACTUAL_RESULT << ", EXPECTED: NULL terminator ('\0')" << std::endl;
     std::cout << "[";
   }
@@ -2410,7 +2957,9 @@ int test_static_callback_note_serial_reset_invokes_noteserial_reset()
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
   NoteSerial_Arduino mockSerial_arduino(Serial,9600);  // Instantiate NoteSerial (mocked)
   make_note_serial_Parameters.reset();
@@ -2418,10 +2967,14 @@ int test_static_callback_note_serial_reset_invokes_noteserial_reset()
   notecard.begin(Serial);  // Provides access to the hidden static callback methods through `note-c` mocks
   noteSerialReset_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   noteSetFnSerial_Parameters.resetfn();
 
-  // Assert
+   // Assert
+  ///////////
+
   if (noteSerialReset_Parameters.invoked)
   {
     result = 0;
@@ -2429,7 +2982,7 @@ int test_static_callback_note_serial_reset_invokes_noteserial_reset()
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteSerialReset_Parameters.invoked == " << noteSerialReset_Parameters.invoked << ", EXPECTED: > 0" << std::endl;
     std::cout << "[";
   }
@@ -2441,7 +2994,9 @@ int test_static_callback_note_serial_reset_does_not_modify_interface_method_retu
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
   NoteSerial_Arduino mockSerial_arduino(Serial,9600);  // Instantiate NoteSerial (mocked)
   make_note_serial_Parameters.reset();
@@ -2450,10 +3005,14 @@ int test_static_callback_note_serial_reset_does_not_modify_interface_method_retu
   noteSerialReset_Parameters.reset();  // Clear the structure for testing results
   noteSerialReset_Parameters.result = true;
 
-  // Action
+   // Action
+  ///////////
+
   const bool ACTUAL_RESULT = noteSetFnSerial_Parameters.resetfn();
 
-  // Assert
+   // Assert
+  ///////////
+
   if (ACTUAL_RESULT == noteSerialReset_Parameters.result)
   {
     result = 0;
@@ -2461,7 +3020,7 @@ int test_static_callback_note_serial_reset_does_not_modify_interface_method_retu
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tACTUAL_RESULT == " << ACTUAL_RESULT << ", EXPECTED: " << noteSerialReset_Parameters.result << std::endl;
     std::cout << "[";
   }
@@ -2473,16 +3032,22 @@ int test_static_callback_note_serial_reset_does_not_call_interface_method_when_i
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
   make_note_serial_Parameters.reset();
   notecard.begin(Serial);  // Provides access to the hidden static callback methods through `note-c` mocks
   noteSerialReset_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   noteSetFnSerial_Parameters.resetfn();
 
-  // Assert
+   // Assert
+  ///////////
+
   if (!noteSerialReset_Parameters.invoked)
   {
     result = 0;
@@ -2490,7 +3055,7 @@ int test_static_callback_note_serial_reset_does_not_call_interface_method_when_i
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteSerialReset_Parameters.invoked == " << noteSerialReset_Parameters.invoked << ", EXPECTED: zero (0)" << std::endl;
     std::cout << "[";
   }
@@ -2502,16 +3067,22 @@ int test_static_callback_note_serial_reset_returns_false_when_interface_has_not_
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   Notecard notecard;
   make_note_serial_Parameters.reset();
   notecard.begin(Serial);  // Provides access to the hidden static callback methods through `note-c` mocks
   noteSerialReset_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   const bool ACTUAL_RESULT = noteSetFnSerial_Parameters.resetfn();
 
-  // Assert
+   // Assert
+  ///////////
+
   if (!ACTUAL_RESULT)
   {
     result = 0;
@@ -2519,7 +3090,7 @@ int test_static_callback_note_serial_reset_returns_false_when_interface_has_not_
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tACTUAL_RESULT == " << ACTUAL_RESULT << ", EXPECTED: false (0)" << std::endl;
     std::cout << "[";
   }
@@ -2531,7 +3102,9 @@ int test_static_callback_note_serial_transmit_invokes_noteserial_transmit()
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   uint8_t text[] = "Test passed!";
   const size_t LEN = sizeof(text);
   const bool FLUSH = true;
@@ -2543,10 +3116,14 @@ int test_static_callback_note_serial_transmit_invokes_noteserial_transmit()
   notecard.begin(Serial);  // Provides access to the hidden static callback methods through `note-c` mocks
   noteSerialTransmit_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   noteSetFnSerial_Parameters.writefn(text, LEN, FLUSH);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (noteSerialTransmit_Parameters.invoked)
   {
     result = 0;
@@ -2554,7 +3131,7 @@ int test_static_callback_note_serial_transmit_invokes_noteserial_transmit()
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\noteSerialTransmit_Parameters.invoked == " << noteSerialTransmit_Parameters.invoked << ", EXPECTED: > 0" << std::endl;
     std::cout << "[";
   }
@@ -2566,7 +3143,9 @@ int test_static_callback_note_serial_transmit_does_not_modify_text_parameter_bef
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   uint8_t expected_text[] = "Test passed!";
   const size_t LEN = sizeof(expected_text);
   const bool FLUSH = true;
@@ -2578,10 +3157,14 @@ int test_static_callback_note_serial_transmit_does_not_modify_text_parameter_bef
   notecard.begin(Serial);  // Provides access to the hidden static callback methods through `note-c` mocks
   noteSerialTransmit_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   noteSetFnSerial_Parameters.writefn(expected_text, LEN, FLUSH);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (!strcmp(reinterpret_cast<char *>(expected_text),reinterpret_cast<char *>(noteSerialTransmit_Parameters.buffer)))
   {
     result = 0;
@@ -2589,7 +3172,7 @@ int test_static_callback_note_serial_transmit_does_not_modify_text_parameter_bef
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\noteSerialTransmit_Parameters.buffer == " << noteSerialTransmit_Parameters.buffer << ", EXPECTED: " << expected_text << std::endl;
     std::cout << "[";
   }
@@ -2601,7 +3184,9 @@ int test_static_callback_note_serial_transmit_does_not_modify_length_parameter_b
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   uint8_t text[] = "Test passed!";
   const size_t EXPECTED_LEN = sizeof(text);
   const bool FLUSH = true;
@@ -2613,10 +3198,14 @@ int test_static_callback_note_serial_transmit_does_not_modify_length_parameter_b
   notecard.begin(Serial);  // Provides access to the hidden static callback methods through `note-c` mocks
   noteSerialTransmit_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   noteSetFnSerial_Parameters.writefn(text, EXPECTED_LEN, FLUSH);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (EXPECTED_LEN == noteSerialTransmit_Parameters.size)
   {
     result = 0;
@@ -2624,7 +3213,7 @@ int test_static_callback_note_serial_transmit_does_not_modify_length_parameter_b
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\noteSerialTransmit_Parameters.size == " << noteSerialTransmit_Parameters.size << ", EXPECTED: " << EXPECTED_LEN << std::endl;
     std::cout << "[";
   }
@@ -2636,7 +3225,9 @@ int test_static_callback_note_serial_transmit_does_not_modify_flush_parameter_be
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   uint8_t text[] = "Test passed!";
   const size_t LEN = sizeof(text);
   const bool EXPECTED_FLUSH = true;
@@ -2648,10 +3239,14 @@ int test_static_callback_note_serial_transmit_does_not_modify_flush_parameter_be
   notecard.begin(Serial);  // Provides access to the hidden static callback methods through `note-c` mocks
   noteSerialTransmit_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   noteSetFnSerial_Parameters.writefn(text, LEN, EXPECTED_FLUSH);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (EXPECTED_FLUSH == noteSerialTransmit_Parameters.flush)
   {
     result = 0;
@@ -2659,7 +3254,7 @@ int test_static_callback_note_serial_transmit_does_not_modify_flush_parameter_be
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\noteSerialTransmit_Parameters.flush == " << noteSerialTransmit_Parameters.flush << ", EXPECTED: " << EXPECTED_FLUSH << std::endl;
     std::cout << "[";
   }
@@ -2671,7 +3266,9 @@ int test_static_callback_note_serial_transmit_does_not_call_interface_method_whe
 {
   int result;
 
-  // Arrange
+   // Arrange
+  ////////////
+
   uint8_t text[] = "Test passed!";
   const size_t LEN = sizeof(text);
   const bool EXPECTED_FLUSH = true;
@@ -2681,10 +3278,14 @@ int test_static_callback_note_serial_transmit_does_not_call_interface_method_whe
   notecard.begin(Serial);  // Provides access to the hidden static callback methods through `note-c` mocks
   noteSerialTransmit_Parameters.reset();  // Clear the structure for testing results
 
-  // Action
+   // Action
+  ///////////
+
   noteSetFnSerial_Parameters.writefn(text, LEN, EXPECTED_FLUSH);
 
-  // Assert
+   // Assert
+  ///////////
+
   if (!noteSerialTransmit_Parameters.invoked)
   {
     result = 0;
@@ -2692,7 +3293,7 @@ int test_static_callback_note_serial_transmit_does_not_call_interface_method_whe
   else
   {
     result = static_cast<int>('c' + 'a' + 'l' + 'l' + 'b' + 'a' + 'c' + 'k');
-    std::cout << "FAILED] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
     std::cout << "\tnoteSerialTransmit_Parameters.invoked == " << noteSerialTransmit_Parameters.invoked << ", EXPECTED: zero (0)" << std::endl;
     std::cout << "[";
   }
@@ -2728,7 +3329,9 @@ int main(void)
       {test_notecard_begin_serial_initializes_the_provided_serial_interface_with_provided_speed, "test_notecard_begin_serial_initializes_the_provided_serial_interface_with_provided_speed"},
       {test_notecard_begin_serial_initializes_the_provided_serial_interface_with_default_speed, "test_notecard_begin_serial_initializes_the_provided_serial_interface_with_default_speed"},
       {test_notecard_begin_serial_sets_user_agent_to_note_arduino, "test_notecard_begin_serial_sets_user_agent_to_note_arduino"},
+      {test_notecard_setDebugOutputStream_does_not_modify_log_channel_parameter_before_passing_to_make_note_log, "test_notecard_setDebugOutputStream_does_not_modify_log_channel_parameter_before_passing_to_make_note_log"},
       {test_notecard_setDebugOutputStream_shares_a_debug_log_functon_pointer, "test_notecard_setDebugOutputStream_shares_a_debug_log_functon_pointer"},
+      {test_notecard_setDebugOutputStream_clears_the_debug_log_functon_pointer_when_nullptr_is_provided, "test_notecard_setDebugOutputStream_clears_the_debug_log_functon_pointer_when_nullptr_is_provided"},
       {test_notecard_clearDebugOutputStream_clears_the_debug_log_functon_pointer, "test_notecard_clearDebugOutputStream_clears_the_debug_log_functon_pointer"},
       {test_notecard_newRequest_does_not_modify_string_parameter_value_before_passing_to_note_c, "test_notecard_newRequest_does_not_modify_string_parameter_value_before_passing_to_note_c"},
       {test_notecard_newRequest_does_not_modify_note_c_result_value_before_returning_to_caller, "test_notecard_newRequest_does_not_modify_note_c_result_value_before_returning_to_caller"},
@@ -2766,11 +3369,11 @@ int main(void)
       {test_static_callback_note_i2c_transmit_does_not_modify_size_parameter_before_passing_to_interface_method, "test_static_callback_note_i2c_transmit_does_not_modify_size_parameter_before_passing_to_interface_method"},
       {test_static_callback_note_i2c_transmit_does_not_call_interface_method_when_interface_has_not_been_instantiated, "test_static_callback_note_i2c_transmit_does_not_call_interface_method_when_interface_has_not_been_instantiated"},
       {test_static_callback_note_i2c_transmit_returns_error_message_when_interface_has_not_been_instantiated, "test_static_callback_note_i2c_transmit_returns_error_message_when_interface_has_not_been_instantiated"},
-      {test_static_callback_note_log_print_invokes_notelog_print, "test_static_callback_note_i2c_reset_invokes_notei2c_receive"},
+      {test_static_callback_note_log_print_invokes_notelog_print, "test_static_callback_note_log_print_invokes_notelog_print"},
       {test_static_callback_note_log_print_does_not_modify_message_parameter_before_passing_to_interface_method, "test_static_callback_note_log_print_does_not_modify_message_parameter_before_passing_to_interface_method"},
-      {test_static_callback_note_log_print_does_not_modify_interface_method_return_value, "test_static_callback_note_i2c_reset_does_not_modify_interface_method_return_value"},
-      {test_static_callback_note_log_print_does_not_call_interface_method_when_interface_has_not_been_instantiated, "test_static_callback_note_i2c_reset_does_not_call_interface_method_when_interface_has_not_been_instantiated"},
-      {test_static_callback_note_log_print_returns_false_when_interface_has_not_been_instantiated, "test_static_callback_note_i2c_reset_returns_false_when_interface_has_not_been_instantiated"},
+      {test_static_callback_note_log_print_does_not_modify_interface_method_return_value, "test_static_callback_note_log_print_does_not_modify_interface_method_return_value"},
+      {test_static_callback_note_log_print_does_not_call_interface_method_when_interface_has_not_been_instantiated, "test_static_callback_note_log_print_does_not_call_interface_method_when_interface_has_not_been_instantiated"},
+      {test_static_callback_note_log_print_returns_false_when_interface_has_not_been_instantiated, "test_static_callback_note_log_print_returns_false_when_interface_has_not_been_instantiated"},
       {test_static_callback_note_serial_available_invokes_noteserial_available, "test_static_callback_note_serial_available_invokes_noteserial_available"},
       {test_static_callback_note_serial_available_does_not_modify_interface_method_return_value, "test_static_callback_note_serial_available_does_not_modify_interface_method_return_value"},
       {test_static_callback_note_serial_available_does_not_call_interface_method_when_interface_has_not_been_instantiated, "test_static_callback_note_serial_available_does_not_call_interface_method_when_interface_has_not_been_instantiated"},

--- a/test/mock/NoteI2c_Mock.cpp
+++ b/test/mock/NoteI2c_Mock.cpp
@@ -1,7 +1,5 @@
 #include "mock/NoteI2c_Mock.hpp"
 
-#include "NoteI2c_Arduino.hpp"
-
 MakeNoteI2c_Parameters make_note_i2c_Parameters;
 NoteI2cReceive_Parameters noteI2cReceive_Parameters;
 NoteI2cReset_Parameters noteI2cReset_Parameters;
@@ -22,16 +20,8 @@ make_note_i2c (
     return make_note_i2c_Parameters.result;
 }
 
-NoteI2c_Arduino::NoteI2c_Arduino (
-    TwoWire & i2c_bus_
-) :
-    _i2cPort(i2c_bus_)
-{
-
-}
-
 const char *
-NoteI2c_Arduino::receive (
+NoteI2c_Mock::receive (
     uint16_t device_address_,
     uint8_t * buffer_,
     uint16_t requested_byte_count_,
@@ -51,7 +41,7 @@ NoteI2c_Arduino::receive (
 }
 
 bool
-NoteI2c_Arduino::reset (
+NoteI2c_Mock::reset (
     uint16_t device_address_
 ) {
     // Record invocation(s)
@@ -65,7 +55,7 @@ NoteI2c_Arduino::reset (
 }
 
 const char *
-NoteI2c_Arduino::transmit (
+NoteI2c_Mock::transmit (
     uint16_t device_address_,
     uint8_t * buffer_,
     uint16_t size_
@@ -76,6 +66,9 @@ NoteI2c_Arduino::transmit (
     // Stash parameter(s)
     noteI2cTransmit_Parameters.device_address = device_address_;
     noteI2cTransmit_Parameters.buffer = buffer_;
+    if (buffer_) {
+        noteI2cTransmit_Parameters.buffer_cache = reinterpret_cast<char *>(buffer_);
+    }
     noteI2cTransmit_Parameters.size = size_;
 
     // Return user-supplied result

--- a/test/mock/NoteI2c_Mock.hpp
+++ b/test/mock/NoteI2c_Mock.hpp
@@ -1,10 +1,20 @@
-#ifndef MOCK_I2C_ARDUINO_HPP
-#define MOCK_I2C_ARDUINO_HPP
+#ifndef MOCK_NOTE_I2C_HPP
+#define MOCK_NOTE_I2C_HPP
 
 #include <stddef.h>
 #include <stdint.h>
 
+#include <string>
+
 #include "NoteI2c.hpp"
+
+class NoteI2c_Mock final : public NoteI2c
+{
+public:
+    const char * receive(uint16_t device_address, uint8_t * buffer, uint16_t requested_byte_count, uint32_t * available) override;
+    bool reset(uint16_t device_address) override;
+    const char * transmit(uint16_t device_address, uint8_t * buffer, uint16_t size) override;
+};
 
 struct MakeNoteI2c_Parameters {
     MakeNoteI2c_Parameters(
@@ -43,6 +53,7 @@ struct NoteI2cReceive_Parameters {
         invoked = 0;
         device_address = 0;
         buffer = nullptr;
+        buffer_cache.clear();
         requested_byte_count = 0;
         available = nullptr;
         result = nullptr;
@@ -50,6 +61,7 @@ struct NoteI2cReceive_Parameters {
     size_t invoked;
     uint16_t device_address;
     uint8_t * buffer;
+    std::string buffer_cache;
     uint16_t requested_byte_count;
     uint32_t * available;
     const char * result;
@@ -91,12 +103,14 @@ struct NoteI2cTransmit_Parameters {
         invoked = 0;
         device_address = 0;
         buffer = nullptr;
+        buffer_cache.clear();
         size = 0;
         result = nullptr;
     }
     size_t invoked;
     uint16_t device_address;
     uint8_t * buffer;
+    std::string buffer_cache;
     uint16_t size;
     const char * result;
 };
@@ -106,4 +120,4 @@ extern NoteI2cReceive_Parameters noteI2cReceive_Parameters;
 extern NoteI2cReset_Parameters noteI2cReset_Parameters;
 extern NoteI2cTransmit_Parameters noteI2cTransmit_Parameters;
 
-#endif // MOCK_I2C_ARDUINO_HPP
+#endif // MOCK_NOTE_I2C_HPP

--- a/test/mock/NoteLog_Mock.cpp
+++ b/test/mock/NoteLog_Mock.cpp
@@ -1,7 +1,5 @@
 #include "mock/NoteLog_Mock.hpp"
 
-#include "NoteLog_Arduino.hpp"
-
 MakeNoteLog_Parameters make_note_log_Parameters;
 NoteLogPrint_Parameters noteLogPrint_Parameters;
 
@@ -20,16 +18,8 @@ make_note_log (
     return make_note_log_Parameters.result;
 }
 
-NoteLog_Arduino::NoteLog_Arduino (
-    Stream * log_stream_
-) :
-    _notecardLog(log_stream_)
-{
-
-}
-
 size_t
-NoteLog_Arduino::print (
+NoteLog_Mock::print (
     const char * message_
 )
 {

--- a/test/mock/NoteLog_Mock.hpp
+++ b/test/mock/NoteLog_Mock.hpp
@@ -1,5 +1,5 @@
-#ifndef MOCK_LOG_ARDUINO_HPP
-#define MOCK_LOG_ARDUINO_HPP
+#ifndef MOCK_NOTE_LOG_HPP
+#define MOCK_NOTE_LOG_HPP
 
 #include <stddef.h>
 #include <stdint.h>
@@ -55,4 +55,4 @@ struct NoteLogPrint_Parameters {
 extern MakeNoteLog_Parameters make_note_log_Parameters;
 extern NoteLogPrint_Parameters noteLogPrint_Parameters;
 
-#endif // MOCK_LOG_ARDUINO_HPP
+#endif // MOCK_NOTE_LOG_HPP

--- a/test/mock/NoteLog_Mock.hpp
+++ b/test/mock/NoteLog_Mock.hpp
@@ -6,6 +6,12 @@
 
 #include "NoteLog.hpp"
 
+class NoteLog_Mock final : public NoteLog
+{
+public:
+    size_t print(const char * message) override;
+};
+
 struct MakeNoteLog_Parameters {
     MakeNoteLog_Parameters(
         void

--- a/test/mock/NoteSerial_Mock.cpp
+++ b/test/mock/NoteSerial_Mock.cpp
@@ -1,7 +1,5 @@
 #include "mock/NoteSerial_Mock.hpp"
 
-#include "NoteSerial_Arduino.hpp"
-
 MakeNoteSerial_Parameters make_note_serial_Parameters;
 NoteSerialAvailable_Parameters noteSerialAvailable_Parameters;
 NoteSerialReceive_Parameters noteSerialReceive_Parameters;
@@ -25,18 +23,8 @@ make_note_serial (
     return make_note_serial_Parameters.result;
 }
 
-NoteSerial_Arduino::NoteSerial_Arduino (
-    HardwareSerial & hw_serial_,
-    size_t baud_rate_
-) :
-    _notecardSerial(hw_serial_),
-    _notecardSerialSpeed(baud_rate_)
-{
-
-}
-
 size_t
-NoteSerial_Arduino::available (
+NoteSerial_Mock::available (
     void
 )
 {
@@ -50,7 +38,7 @@ NoteSerial_Arduino::available (
 }
 
 char
-NoteSerial_Arduino::receive (
+NoteSerial_Mock::receive (
     void
 )
 {
@@ -64,7 +52,7 @@ NoteSerial_Arduino::receive (
 }
 
 bool
-NoteSerial_Arduino::reset (
+NoteSerial_Mock::reset (
     void
 )
 {
@@ -78,7 +66,7 @@ NoteSerial_Arduino::reset (
 }
 
 size_t
-NoteSerial_Arduino::transmit (
+NoteSerial_Mock::transmit (
     uint8_t *buffer_,
     size_t size_,
     bool flush_

--- a/test/mock/NoteSerial_Mock.hpp
+++ b/test/mock/NoteSerial_Mock.hpp
@@ -1,5 +1,5 @@
-#ifndef MOCK_SERIAL_ARDUINO_HPP
-#define MOCK_SERIAL_ARDUINO_HPP
+#ifndef MOCK_NOTE_SERIAL_HPP
+#define MOCK_NOTE_SERIAL_HPP
 
 #include <stddef.h>
 #include <stdint.h>
@@ -121,4 +121,4 @@ extern NoteSerialReceive_Parameters noteSerialReceive_Parameters;
 extern NoteSerialReset_Parameters noteSerialReset_Parameters;
 extern NoteSerialTransmit_Parameters noteSerialTransmit_Parameters;
 
-#endif // MOCK_SERIAL_ARDUINO_HPP
+#endif // MOCK_NOTE_SERIAL_HPP

--- a/test/mock/NoteSerial_Mock.hpp
+++ b/test/mock/NoteSerial_Mock.hpp
@@ -6,6 +6,15 @@
 
 #include "NoteSerial.hpp"
 
+class NoteSerial_Mock final : public NoteSerial
+{
+public:
+    size_t available(void) override;
+    char receive(void) override;
+    bool reset(void) override;
+    size_t transmit(uint8_t * buffer, size_t size, bool flush) override;
+};
+
 struct MakeNoteSerial_Parameters {
     MakeNoteSerial_Parameters(
         void

--- a/test/run_all_tests.sh
+++ b/test/run_all_tests.sh
@@ -19,9 +19,10 @@ if [ 0 -eq $all_tests_result ]; then
     test/mock/NoteSerial_Mock.cpp \
     -Isrc \
     -Itest \
-    -DNOTE_MOCK
+    -DNOTE_MOCK \
+    -o failed_test_run
   if [ 0 -eq $? ]; then
-    valgrind --leak-check=full --error-exitcode=66 ./a.out
+    valgrind --leak-check=full --error-exitcode=66 ./failed_test_run
     tests_result=$?
     if [ 0 -eq ${tests_result} ]; then
       echo -e "${GREEN}Notecard tests passed!${DEFAULT}"
@@ -43,9 +44,10 @@ if [ 0 -eq $all_tests_result ]; then
     test/mock/mock-note-c-note.c \
     -Isrc \
     -Itest \
-    -DNOTE_MOCK
+    -DNOTE_MOCK \
+    -o failed_test_run
   if [ 0 -eq $? ]; then
-    valgrind --leak-check=full --error-exitcode=66 ./a.out
+    valgrind --leak-check=full --error-exitcode=66 ./failed_test_run
     tests_result=$?
     if [ 0 -eq ${tests_result} ]; then
       echo -e "${GREEN}NoteI2c_Arduino tests passed!${DEFAULT}"
@@ -68,9 +70,10 @@ if [ 0 -eq $all_tests_result ]; then
     -Isrc \
     -Itest \
     -DNOTE_MOCK \
-    -DWIRE_HAS_END
+    -DWIRE_HAS_END \
+    -o failed_test_run
   if [ 0 -eq $? ]; then
-    valgrind --leak-check=full --error-exitcode=66 ./a.out
+    valgrind --leak-check=full --error-exitcode=66 ./failed_test_run
     tests_result=$?
     if [ 0 -eq ${tests_result} ]; then
       echo -e "${GREEN}NoteI2c_Arduino tests passed! (-DWIRE_HAS_END)${DEFAULT}"
@@ -91,9 +94,10 @@ if [ 0 -eq $all_tests_result ]; then
     test/mock/mock-arduino.cpp \
     -Isrc \
     -Itest \
-    -DNOTE_MOCK
+    -DNOTE_MOCK \
+    -o failed_test_run
   if [ 0 -eq $? ]; then
-    valgrind --leak-check=full --error-exitcode=66 ./a.out
+    valgrind --leak-check=full --error-exitcode=66 ./failed_test_run
     tests_result=$?
     if [ 0 -eq ${tests_result} ]; then
       echo -e "${GREEN}NoteLog_Arduino tests passed!${DEFAULT}"
@@ -114,9 +118,10 @@ if [ 0 -eq $all_tests_result ]; then
     test/mock/mock-arduino.cpp \
     -Isrc \
     -Itest \
-    -DNOTE_MOCK
+    -DNOTE_MOCK \
+    -o failed_test_run
   if [ 0 -eq $? ]; then
-    valgrind --leak-check=full --error-exitcode=66 ./a.out
+    valgrind --leak-check=full --error-exitcode=66 ./failed_test_run
     tests_result=$?
     if [ 0 -eq ${tests_result} ]; then
       echo -e "${GREEN}NoteSerial_Arduino tests passed!${DEFAULT}"
@@ -151,11 +156,12 @@ if [ 0 -eq ${all_tests_result} ]; then
       lcov --summary ./coverage/lcov.info
     fi
   fi
+  rm -f failed_test_run
 else
   echo && echo -e "${RED}TESTS FAILED!!!${DEFAULT}"
 fi
 
 # Clean testing artifacts
-rm -f *.gcda *.gcno ./a.out
+rm -f *.gcda *.gcno
 
 exit $all_tests_result


### PR DESCRIPTION
This simple abstraction fully isolates the Arduino `Stream` object, and demonstrates the path to abstraction for both `Serial` and `I2C`.