### PR TITLE
clarification on setting PRODUCT_UID

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ with:
 - [Handling inbound requests with polling](examples/Example3_InboundPolling/Example3_InboundPolling.ino)
 - [Handling inbound interrupts](examples/Example4_InboundInterrupts/Example4_InboundInterrupts.ino)
 - [Using Note templates](examples/Example5_UsingTemplates/Example5_UsingTemplates.ino)
+- [Sensor tutorial](examples/Example6_SensorTutorial/Example6_SensorTutorial.ino)
+- [Power control](examples/Example7_PowerControl/Example7_PowerControl.ino)
+
+Before running an example, you will need to set the Product Identifier, either in code or on your connected Notecard. Steps on how to do this can be found at [https://dev.blues.io/tools-and-sdks/samples/product-uid](https://dev.blues.io/tools-and-sdks/samples/product-uid).
+
 
 ## Contributing
 

--- a/examples/Example0_LibrarylessCommunication/Example0_LibrarylessCommunication.ino
+++ b/examples/Example0_LibrarylessCommunication/Example0_LibrarylessCommunication.ino
@@ -34,7 +34,12 @@
 // "claim" a unique product ID for your device.  It could be something as simple as as your email
 // address in reverse, such as "com.gmail.smith.lisa.test-device" or "com.outlook.gates.bill.demo"
 
-#define myProductID "com.your-company.your-name:your_project"
+// This is the unique Product Identifier for your device
+#ifndef PRODUCT_UID
+#define PRODUCT_UID ""		// "com.my-company.my-name:my-project"
+#pragma message "PRODUCT_UID is not defined in this example. Please ensure your Notecard has a product identifier set before running this example or define it in code here. More details at https://dev.blues.io/tools-and-sdks/samples/product-uid"
+#endif
+#define myProductID PRODUCT_UID
 #define myLiveDemo  true
 
 // One-time Arduino initialization
@@ -51,16 +56,17 @@ void setup()
 
     // This command (required) causes the data to be delivered to the Project on notehub.io that has claimed
     // this Product ID.  (see above)
-    txRxPinsSerial.println("{\"req\":\"service.set\",\"product\":\"" myProductID "\"}");
-
+    if (myProductID[0]) {
+        txRxPinsSerial.println("{\"req\":\"hub.set\",\"product\":\"" myProductID "\"}");
+    }
     // This command determines how often the Notecard connects to the service.  If "continuous" the Notecard
     // immediately establishes a session with the service at notehub.io, and keeps it active continuously.
     // Because of the power requirements of a continuous connection, a battery powered device would instead
     // only sample its sensors occasionally, and would only upload to the service on a periodic basis.
 #if myLiveDemo
-    txRxPinsSerial.println("{\"req\":\"service.set\",\"mode\":\"continuous\"}");
+    txRxPinsSerial.println("{\"req\":\"hub.set\",\"mode\":\"continuous\"}");
 #else
-    txRxPinsSerial.println("{\"req\":\"service.set\",\"mode\":\"periodic\",\"outbound\":60}");
+    txRxPinsSerial.println("{\"req\":\"hub.set\",\"mode\":\"periodic\",\"outbound\":60}");
 #endif
 
 }

--- a/examples/Example1_NotecardBasics/Example1_NotecardBasics.ino
+++ b/examples/Example1_NotecardBasics/Example1_NotecardBasics.ino
@@ -42,7 +42,13 @@
 // "claim" a unique product ID for your device.  It could be something as simple as as your email
 // address in reverse, such as "com.gmail.smith.lisa:test-device" or "com.outlook.gates.bill.demo"
 
-#define myProductID "com.your-company.your-name:your_project"
+// This is the unique Product Identifier for your device
+#ifndef PRODUCT_UID
+#define PRODUCT_UID ""		// "com.my-company.my-name:my-project"
+#pragma message "PRODUCT_UID is not defined in this example. Please ensure your Notecard has a product identifier set before running this example or define it in code here. More details at https://dev.blues.io/tools-and-sdks/samples/product-uid"
+#endif
+
+#define myProductID PRODUCT_UID
 Notecard notecard;
 
 // One-time Arduino initialization
@@ -79,8 +85,9 @@ void setup()
 
     // This command (required) causes the data to be delivered to the Project on notehub.io that has claimed
     // this Product ID.  (see above)
-    JAddStringToObject(req, "product", myProductID);
-
+    if (myProductID[0]) {
+        JAddStringToObject(req, "product", myProductID);
+    }
     // This command determines how often the Notecard connects to the service.  If "continuous" the Notecard
     // immediately establishes a session with the service at notehub.io, and keeps it active continuously.
     // Because of the power requirements of a continuous connection, a battery powered device would instead

--- a/examples/Example2_PeriodicCommunications/Example2_PeriodicCommunications.ino
+++ b/examples/Example2_PeriodicCommunications/Example2_PeriodicCommunications.ino
@@ -55,8 +55,13 @@
 // #define txRxPinsSerial Serial1
 #define usbSerial Serial
 
-// This is the unique Product Identifier for your device.
-#define myProductID "com.your-company.your-name:your_project"
+// This is the unique Product Identifier for your device
+#ifndef PRODUCT_UID
+#define PRODUCT_UID ""		// "com.my-company.my-name:my-project"
+#pragma message "PRODUCT_UID is not defined in this example. Please ensure your Notecard has a product identifier set before running this example or define it in code here. More details at https://dev.blues.io/tools-and-sdks/samples/product-uid"
+#endif
+
+#define myProductID PRODUCT_UID
 Notecard notecard;
 
 // Button handling
@@ -96,8 +101,9 @@ void setup()
 
     // This command (required) causes the data to be delivered to the Project on notehub.io that has claimed
     // this Product ID.  (see above)
-    JAddStringToObject(req, "product", myProductID);
-
+    if (myProductID[0]) {
+        JAddStringToObject(req, "product", myProductID);
+    }
     // This sets the notecard's connectivity mode to periodic, rather than being continuously connected
     JAddStringToObject(req, "mode", "periodic");
 

--- a/examples/Example3_InboundPolling/Example3_InboundPolling.ino
+++ b/examples/Example3_InboundPolling/Example3_InboundPolling.ino
@@ -32,8 +32,13 @@
 // #define txRxPinsSerial Serial1
 #define usbSerial Serial
 
-// This is the unique Product Identifier for your device.
-#define myProductID "com.your-company.your-name:your_project"
+// This is the unique Product Identifier for your device
+#ifndef PRODUCT_UID
+#define PRODUCT_UID ""		// "com.my-company.my-name:my-project"
+#pragma message "PRODUCT_UID is not defined in this example. Please ensure your Notecard has a product identifier set before running this example or define it in code here. More details at https://dev.blues.io/tools-and-sdks/samples/product-uid"
+#endif
+
+#define myProductID PRODUCT_UID
 Notecard notecard;
 #define myLiveDemo  true
 
@@ -59,7 +64,9 @@ void setup()
 
     // Configure the productUID, and instruct the Notecard to stay connected to the service
     J *req = notecard.newRequest("hub.set");
-    JAddStringToObject(req, "product", myProductID);
+    if (myProductID[0]) {
+        JAddStringToObject(req, "product", myProductID);
+    }
 #if myLiveDemo
     JAddStringToObject(req, "mode", "continuous");
     JAddBoolToObject(req, "sync", true);  // Automatically sync when changes are made on notehub

--- a/examples/Example4_InboundInterrupts/Example4_InboundInterrupts.ino
+++ b/examples/Example4_InboundInterrupts/Example4_InboundInterrupts.ino
@@ -37,8 +37,13 @@
 // #define txRxPinsSerial Serial1
 #define usbSerial Serial
 
-// This is the unique Product Identifier for your device.
-#define myProductID "com.your-company.your-name:your_project"
+// This is the unique Product Identifier for your device
+#ifndef PRODUCT_UID
+#define PRODUCT_UID ""		// "com.my-company.my-name:my-project"
+#pragma message "PRODUCT_UID is not defined in this example. Please ensure your Notecard has a product identifier set before running this example or define it in code here. More details at https://dev.blues.io/tools-and-sdks/samples/product-uid"
+#endif
+
+#define myProductID PRODUCT_UID
 Notecard notecard;
 #define myLiveDemo  true
 
@@ -70,7 +75,9 @@ void setup()
 
     // Configure the productUID, and instruct the Notecard to stay connected to the service
     J *req = notecard.newRequest("hub.set");
-    JAddStringToObject(req, "product", myProductID);
+    if (myProductID[0]) {
+        JAddStringToObject(req, "product", myProductID);
+    }
 #if myLiveDemo
     JAddStringToObject(req, "mode", "continuous");
     JAddBoolToObject(req, "sync", true);

--- a/examples/Example5_UsingTemplates/Example5_UsingTemplates.ino
+++ b/examples/Example5_UsingTemplates/Example5_UsingTemplates.ino
@@ -41,7 +41,14 @@
 // of "managing" it.  In order to set this value, you must first register with notehub.io and
 // "claim" a unique product ID for your device.  It could be something as simple as as your email
 // address in reverse, such as "com.gmail.smith.lisa.test-device" or "com.outlook.gates.bill.demo"
-#define myProductID "com.your-company.your-name:your_project"
+
+// This is the unique Product Identifier for your device
+#ifndef PRODUCT_UID
+#define PRODUCT_UID ""		// "com.my-company.my-name:my-project"
+#pragma message "PRODUCT_UID is not defined in this example. Please ensure your Notecard has a product identifier set before running this example or define it in code here. More details at https://dev.blues.io/tools-and-sdks/samples/product-uid"
+#endif
+
+#define myProductID PRODUCT_UID
 Notecard notecard;
 
 // A sample binary object, just for binary payload simulation
@@ -77,8 +84,9 @@ void setup()
 
     // This command (required) causes the data to be delivered to the Project on notehub.io that has claimed
     // this Product ID.  (see above)
-    JAddStringToObject(req, "product", myProductID);
-
+    if (myProductID[0]) {
+        JAddStringToObject(req, "product", myProductID);
+    }
     // This command determines how often the Notecard connects to the service.
     JAddStringToObject(req, "mode", "periodic");
     JAddNumberToObject(req, "outbound", 5);

--- a/examples/Example6_SensorTutorial/Example6_SensorTutorial.ino
+++ b/examples/Example6_SensorTutorial/Example6_SensorTutorial.ino
@@ -20,7 +20,13 @@ Adafruit_BME680 bmeSensor;
 //#define txRxPinsSerial Serial1
 #define usbSerial Serial
 
-#define productUID "com.your-company.your-name:your_project"
+// This is the unique Product Identifier for your device
+#ifndef PRODUCT_UID
+#define PRODUCT_UID ""		// "com.my-company.my-name:my-project"
+#pragma message "PRODUCT_UID is not defined in this example. Please ensure your Notecard has a product identifier set before running this example or define it in code here. More details at https://dev.blues.io/tools-and-sdks/samples/product-uid"
+#endif
+
+#define myProductID PRODUCT_UID
 Notecard notecard;
 
 // One-time Arduino initialization
@@ -42,7 +48,9 @@ void setup()
 #endif
 
     J *req = notecard.newRequest("hub.set");
-    JAddStringToObject(req, "product", productUID);
+    if (myProductID[0]) {
+        JAddStringToObject(req, "product", myProductID);
+    }
     JAddStringToObject(req, "mode", "continuous");
     notecard.sendRequest(req);
 

--- a/examples/Example7_PowerControl/Example7_PowerControl.ino
+++ b/examples/Example7_PowerControl/Example7_PowerControl.ino
@@ -14,7 +14,16 @@
 #include <Wire.h>
 
 // Parameters for this example
-#define notehubProductUID		"com.your_company.your_name:your_project"	// if you're your_name@your_company.com
+
+// This is the unique Product Identifier for your device
+#ifndef PRODUCT_UID
+#define PRODUCT_UID ""		// "com.my-company.my-name:my-project"
+#pragma message "PRODUCT_UID is not defined in this example. Please ensure your Notecard has a product identifier set before running this example or define it in code here. More details at https://dev.blues.io/tools-and-sdks/samples/product-uid"
+#endif
+
+#define myProductID PRODUCT_UID
+
+#define notehubProductUID		PRODUCT_UID
 #define notehubUploadPeriodMins	10
 #define	hostSleepSeconds		60
 
@@ -84,7 +93,9 @@ void setup()
 
 		// Initialize the Notecard
 	    J *req = NoteNewRequest("hub.set");
-	    JAddStringToObject(req, "product", notehubProductUID);
+		if (notehubProductUID[0]) {
+		    JAddStringToObject(req, "product", notehubProductUID);
+		}
 	    JAddStringToObject(req, "mode", "periodic");
 	    JAddNumberToObject(req, "outbound", notehubUploadPeriodMins);
 	    NoteRequest(req);


### PR DESCRIPTION
Adds clarification and a link about setting the product identifier if it is not defined in code. Adds missing links to examples 6 and 7 in README.md.

PR should not be merged until we have the page referenced on dev.blues.io.