### PR TITLE
BREAK: Swap Swan v1/v3 `B0` Support

### DIFF
--- a/src/Notecarrier.h
+++ b/src/Notecarrier.h
@@ -155,15 +155,22 @@
 
 #elif defined(ARDUINO_SWAN_R5)
 
+// Swan v1 (deprecated)
 #ifdef CS
 #undef CS
 #endif
 #define CS PD0
 
+#ifdef B0_V1
+#undef B0_V1
+#endif
+#define B0_V1 CS
+
+// Swan v3
 #ifdef B0
 #undef B0
 #endif
-#define B0 CS
+#define B0 PH3
 
 #endif
 


### PR DESCRIPTION
- `B0` #define now supports Swan v3 (`PH3`)
- Swan v1 (deprecated) must now use `B0_V1`, instead of `B0` to maintain functionality in previously compiled programs

_**NOTE:** `CS` pin (`PD0`) is no longer exposed via Swan v3 Feather headers (castellated only)_