### PR TITLE
Remove references to note-c as a git submodule.

### DIFF
--- a/.github/workflows/note-arduino-ci.yml
+++ b/.github/workflows/note-arduino-ci.yml
@@ -13,8 +13,6 @@ jobs:
       - name: Checkout Code
         id: checkout
         uses: actions/checkout@v2
-        with:
-          submodules: true
       - name: Run Tests In Container
         id: containerized_tests
         uses: ./.github/actions/run-tests-in-container
@@ -55,8 +53,6 @@ jobs:
       - name: Checkout Code
         id: checkout
         uses: actions/checkout@v2
-        with:
-          submodules: true
       - name: Compile Examples
         id: compile_examples
         uses: ./.github/actions/compile-examples

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ or C++. Your sketch may programmatically configure Notecard and send Notes to
 [Notehub.io][notehub].
 
 This library is a wrapper around the [note-c library][note-c], which it includes
-as a git submodule.
+as a git subtree.
 
 ## Installation
 

--- a/src/Notecard.cpp
+++ b/src/Notecard.cpp
@@ -17,7 +17,7 @@
  *
  * This library is a wrapper around and depends upon the
  * <a href="https://github.com/blues/note-c">note-c library</a>, which it
- * includes as a git submodule.
+ * includes as a git subtree.
  *
  * In addition, this library requires a physical
  * connection to a Notecard over I2C or Serial to be functional.

--- a/src/Notecard.h
+++ b/src/Notecard.h
@@ -11,7 +11,7 @@
  *
  * This library is a wrapper around the
  * <a href="https://github.com/blues/note-c">note-c library</a>, which it
- * includes as a git submodule.
+ * includes as a git subtree.
  *
  * Written by Ray Ozzie and Brandon Satrom for Blues Inc.
  *


### PR DESCRIPTION
This repo uses a git subtree for note-c, not a submodule.