### PR TITLE
Improve I2C receive retry logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.gcov
 vgcore.*
 *.tests
+failed_test_run
 
 .vscode/
 build/

--- a/src/NoteI2c_Arduino.cpp
+++ b/src/NoteI2c_Arduino.cpp
@@ -89,9 +89,9 @@ NoteI2c_Arduino::receive (
                 result = ERRSTR("serial-over-i2c: unexpected raw byte count {io}",i2cerr);
             } else {
                 // Ensure available byte count is within expected range
-                static const size_t AVAILBLE_MAX = (NoteI2c::REQUEST_MAX_SIZE - NoteI2c::REQUEST_HEADER_SIZE);
+                static const size_t AVAILABLE_MAX = (NoteI2c::REQUEST_MAX_SIZE - NoteI2c::REQUEST_HEADER_SIZE);
                 uint32_t available = _i2cPort.read();
-                if (available > AVAILBLE_MAX) {
+                if (available > AVAILABLE_MAX) {
                     result = ERRSTR("serial-over-i2c: available byte count greater than max allowed {io}",i2cerr);
                 } else if (requested_byte_count_ != static_cast<uint8_t>(_i2cPort.read())) {
                     // Ensure protocol response length matches size request

--- a/src/NoteI2c_Arduino.cpp
+++ b/src/NoteI2c_Arduino.cpp
@@ -52,6 +52,10 @@ NoteI2c_Arduino::receive (
         transmission_error = _i2cPort.endTransmission();
 
         switch (transmission_error) {
+        case 0:
+            // I2C transmission was successful
+            result = nullptr;
+            break;
         case 1:
             result = ERRSTR("i2c: data too long to fit in transmit buffer {io}",i2cerr);
             break;
@@ -71,12 +75,12 @@ NoteI2c_Arduino::receive (
             result = ERRSTR("i2c: unknown error encounter during I2C transmission {io}",i2cerr);
         }
 
-        // Delay briefly ensuring that the Notecard can
-        // deliver the data in real-time to the I2C ISR
-        ::delay(2);
-
         // Read and cache response from Notecard
         if (!transmission_error) {
+            // Delay briefly ensuring that the Notecard can
+            // deliver the data in real-time to the I2C ISR
+            ::delay(2);
+
             const int request_length = requested_byte_count_ + NoteI2c::REQUEST_HEADER_SIZE;
             const int response_length = _i2cPort.requestFrom((int)device_address_, request_length);
             if (!response_length) {

--- a/src/NoteI2c_Arduino.cpp
+++ b/src/NoteI2c_Arduino.cpp
@@ -39,19 +39,17 @@ NoteI2c_Arduino::receive (
 )
 {
     const char *result = nullptr;
-    uint8_t transmission_error = 0;
 
-    // Request response data from Notecard
-    for (size_t i = 0 ; i < 3 ; ++i) {
+    const size_t retry_count = 3;
+    size_t i = 0;
+    do {
+        uint8_t transmission_error = 0;
+
+        // Request response data from Notecard
         _i2cPort.beginTransmission(static_cast<uint8_t>(device_address_));
         _i2cPort.write(static_cast<uint8_t>(0));
         _i2cPort.write(static_cast<uint8_t>(requested_byte_count_));
         transmission_error = _i2cPort.endTransmission();
-
-        // Break out of loop on success
-        if (!transmission_error) {
-            break;
-        }
 
         switch (transmission_error) {
         case 1:
@@ -72,42 +70,49 @@ NoteI2c_Arduino::receive (
         default:
             result = ERRSTR("i2c: unknown error encounter during I2C transmission {io}",i2cerr);
         }
-    }
 
-    // Delay briefly ensuring that the Notecard can
-    // deliver the data in real-time to the I2C ISR
-    ::delay(2);
+        // Delay briefly ensuring that the Notecard can
+        // deliver the data in real-time to the I2C ISR
+        ::delay(2);
 
-    // Read and cache response from Notecard
-    if (!transmission_error) {
-        const int request_length = requested_byte_count_ + NoteI2c::REQUEST_HEADER_SIZE;
-        const int response_length = _i2cPort.requestFrom((int)device_address_, request_length);
-        if (!response_length) {
-            result = ERRSTR("serial-over-i2c: no response to read request {io}",i2cerr);
-        } else if (response_length != request_length) {
-            result = ERRSTR("serial-over-i2c: unexpected raw byte count {io}",i2cerr);
-        } else {
-            // Ensure available byte count is within expected range
-            static const size_t AVAILBLE_MAX = (NoteI2c::REQUEST_MAX_SIZE - NoteI2c::REQUEST_HEADER_SIZE);
-            uint32_t available = _i2cPort.read();
-            if (available > AVAILBLE_MAX) {
-                result = ERRSTR("serial-over-i2c: available byte count greater than max allowed {io}",i2cerr);
-            }
-            // Ensure protocol response length matches size request
-            else if (requested_byte_count_ != static_cast<uint8_t>(_i2cPort.read())) {
-                result = ERRSTR("serial-over-i2c: unexpected protocol byte count {io}",i2cerr);
-            }
-            // Update available with remaining bytes
-            else {
-                *available_ = available;
+        // Read and cache response from Notecard
+        if (!transmission_error) {
+            const int request_length = requested_byte_count_ + NoteI2c::REQUEST_HEADER_SIZE;
+            const int response_length = _i2cPort.requestFrom((int)device_address_, request_length);
+            if (!response_length) {
+                result = ERRSTR("serial-over-i2c: no response to read request {io}",i2cerr);
+            } else if (response_length != request_length) {
+                result = ERRSTR("serial-over-i2c: unexpected raw byte count {io}",i2cerr);
+            } else {
+                // Ensure available byte count is within expected range
+                static const size_t AVAILBLE_MAX = (NoteI2c::REQUEST_MAX_SIZE - NoteI2c::REQUEST_HEADER_SIZE);
+                uint32_t available = _i2cPort.read();
+                if (available > AVAILBLE_MAX) {
+                    result = ERRSTR("serial-over-i2c: available byte count greater than max allowed {io}",i2cerr);
+                } else if (requested_byte_count_ != static_cast<uint8_t>(_i2cPort.read())) {
+                    // Ensure protocol response length matches size request
+                    result = ERRSTR("serial-over-i2c: unexpected protocol byte count {io}",i2cerr);
+                } else {
+                    // Update available with remaining bytes
+                    *available_ = available;
 
-                for (size_t i = 0 ; i < requested_byte_count_ ; ++i) {
-                    //TODO: Perf test against indexed buffer writes
-                    *buffer_++ = _i2cPort.read();
+                    for (size_t i = 0 ; i < requested_byte_count_ ; ++i) {
+                        //TODO: Perf test against indexed buffer reads
+                        *buffer_++ = _i2cPort.read();
+                    }
+                    result = nullptr;
+                    break;
                 }
             }
         }
-    }
+
+        // Flash stalls have been observed on the Notecard ESP. Delaying
+        // between retries provides time for the Notecard to recover from
+        // the resource contention.
+        ::delay(1000);
+        NOTE_C_LOG_ERROR(result);
+        NOTE_C_LOG_WARN("serial-over-i2c: reattempting to read Notecard response");
+    } while (result && (i++ < retry_count));
 
     return result;
 }

--- a/test/NoteLog_Arduino.test.cpp
+++ b/test/NoteLog_Arduino.test.cpp
@@ -6,7 +6,7 @@
 #include <cassert>
 #include <cstring>
 
-// Compile command: g++ -Wall -Wextra -Wpedantic mock/mock-arduino.cpp ../src/NoteLog_Arduino.cpp NoteLog_Arduino.test.cpp -std=c++11 -I. -I../src -DNOTE_MOCK && ./a.out || echo "Tests Result: $?"
+// Compile command: g++ -Wall -Wextra -Wpedantic mock/mock-arduino.cpp ../src/NoteLog_Arduino.cpp NoteLog_Arduino.test.cpp -std=c++11 -I. -I../src -DNOTE_MOCK -ggdb -O0 -o noteLog_arduino.tests && ./noteLog_arduino.tests || echo "Tests Result: $?"
 
 int test_make_note_log_instantiates_notelog_object()
 {

--- a/test/NoteSerial_Arduino.test.cpp
+++ b/test/NoteSerial_Arduino.test.cpp
@@ -6,7 +6,7 @@
 #include <cassert>
 #include <cstring>
 
-// Compile command: g++ -Wall -Wextra -Wpedantic mock/mock-arduino.cpp ../src/NoteSerial_Arduino.cpp NoteSerial_Arduino.test.cpp -std=c++11 -I. -I../src -DNOTE_MOCK && ./a.out || echo "Tests Result: $?"
+// Compile command: g++ -Wall -Wextra -Wpedantic mock/mock-arduino.cpp ../src/NoteSerial_Arduino.cpp NoteSerial_Arduino.test.cpp -std=c++11 -I. -I../src -DNOTE_MOCK -ggdb -O0 -o noteSerial_arduino.tests && ./noteSerial_arduino.tests || echo "Tests Result: $?"
 
 int test_make_note_serial_instantiates_noteserial_object()
 {

--- a/test/NoteTxn_Arduino.test.cpp
+++ b/test/NoteTxn_Arduino.test.cpp
@@ -5,7 +5,7 @@
 
 #include <cassert>
 
-// Compile command: g++ -std=c++11 -Wall -Wextra -Wpedantic mock/mock-arduino.cpp ../src/NoteTxn_Arduino.cpp NoteTxn_Arduino.test.cpp -I. -I../src -DNOTE_MOCK && ./a.out || echo "Tests Result: $?"
+// Compile command: g++ -std=c++11 -Wall -Wextra -Wpedantic mock/mock-arduino.cpp ../src/NoteTxn_Arduino.cpp NoteTxn_Arduino.test.cpp -I. -I../src -DNOTE_MOCK -ggdb -O0 -o noteTxn_arduino.tests && ./noteTxn_arduino.tests || echo "Tests Result: $?"
 
 int test_make_note_txn_instantiates_notetxn_object()
 {

--- a/test/Notecard.test.cpp
+++ b/test/Notecard.test.cpp
@@ -12,7 +12,7 @@
 #include "mock/NoteSerial_Mock.hpp"
 #include "mock/NoteTxn_Mock.hpp"
 
-// Compile command: g++ -Wall -Wextra -Wpedantic mock/mock-arduino.cpp mock/mock-note-c-note.c mock/NoteI2c_Mock.cpp mock/NoteLog_Mock.cpp mock/NoteSerial_Mock.cpp mock/NoteTime_Mock.cpp mock/NoteTxn_Mock.cpp ../src/Notecard.cpp Notecard.test.cpp -std=c++11 -I. -I../src -DNOTE_MOCK -o notecard.tests && ./notecard.tests || echo "Tests Result: $?"
+// Compile command: g++ -Wall -Wextra -Wpedantic mock/mock-arduino.cpp mock/mock-note-c-note.c mock/NoteI2c_Mock.cpp mock/NoteLog_Mock.cpp mock/NoteSerial_Mock.cpp mock/NoteTime_Mock.cpp mock/NoteTxn_Mock.cpp ../src/Notecard.cpp Notecard.test.cpp -std=c++11 -I. -I../src -DNOTE_MOCK -ggdb -O0 -o notecard.tests && ./notecard.tests || echo "Tests Result: $?"
 
 int test_notecard_begin_i2c_sets_user_agent_to_note_arduino()
 {

--- a/test/mock/mock-parameters.hpp
+++ b/test/mock/mock-parameters.hpp
@@ -6,6 +6,9 @@
 
 #include "note-c/note.h"
 
+#define NoteDebugWithLevel(...)
+#define NoteDebugWithLevelLn(...)
+
 #ifdef NoteDeleteResponse
 #undef NoteDeleteResponse
 #endif


### PR DESCRIPTION
This modification was made to improve the experience with the Notecard ESP, and has been tested quite extensively.