### PR TITLE
Enable example builds in CI for arduino:mbed_nano:nano33ble.

### DIFF
--- a/.github/workflows/note-arduino-ci.yml
+++ b/.github/workflows/note-arduino-ci.yml
@@ -113,8 +113,7 @@ jobs:
           - adafruit:samd:adafruit_feather_m4
           # The binary examples don't fit in the Uno's flash.
           # - arduino:avr:uno
-          # TODO: Fix this. May require upstream fix.
-          # - arduino:mbed_nano:nano33ble
+          - arduino:mbed_nano:nano33ble
           - esp32:esp32:featheresp32
           - rp2040:rp2040:rpipico
           - SparkFun:apollo3:sfe_artemis_thing_plus


### PR DESCRIPTION
There were some bad versions of arduino:mbed_nano that caused these builds to fail, so we disabled them. With the latest release, 4.0.10, the builds are successful, so we're re-enabling them.