### PR TITLE
Deprecate logDebug and logDebugf.

### DIFF
--- a/src/Notecard.cpp
+++ b/src/Notecard.cpp
@@ -309,31 +309,44 @@ void Notecard::deleteResponse(J *rsp)
 
 /**************************************************************************/
 /*!
+    @deprecated NoteDebug, which this function wraps, should be treated as an
+    internal Notecard logging function, used only by the library itself
+    (note-arduino and note-c) and not its users.
     @brief  Write a message to the serial debug stream.
     @param    message
               A string to log to the serial debug stream.
 */
 /**************************************************************************/
-void Notecard::logDebug(const char *message)
+NOTE_ARDUINO_DEPRECATED void Notecard::logDebug(const char *message)
 {
+#ifdef NOTE_ARDUINO_NO_DEPRECATED_ATTR
+    NOTE_C_LOG_WARN("logDebug is deprecated.")
+#endif
     NoteDebug(message);
 }
 
 /**************************************************************************/
 /*!
+    @deprecated NoteDebug, which this function wraps, should be treated as an
+    internal Notecard logging function, used only by the library itself
+    (note-arduino and note-c) and not its users.
     @brief  Write a formatted message to the serial debug stream.
     @param    format
               A format string to log to the serial debug stream.
     @param    ... one or more values to interpolate into the format string.
 */
 /**************************************************************************/
-void Notecard::logDebugf(const char *format, ...)
+NOTE_ARDUINO_DEPRECATED void Notecard::logDebugf(const char *format, ...)
 {
     char message[256];
     va_list args;
     va_start(args, format);
     vsnprintf(message, sizeof(message), format, args);
     va_end(args);
+
+#ifdef NOTE_ARDUINO_NO_DEPRECATED_ATTR
+    NOTE_C_LOG_WARN("logDebugf is deprecated.")
+#endif
     NoteDebug(message);
 }
 

--- a/src/Notecard.h
+++ b/src/Notecard.h
@@ -45,6 +45,15 @@
 #include "mock/mock-parameters.hpp"
 #endif
 
+#if defined(__GNUC__) | defined(__clang__)
+    #define NOTE_ARDUINO_DEPRECATED __attribute__((__deprecated__))
+#elif defined(_MSC_VER)
+    #define NOTE_ARDUINO_DEPRECATED __declspec(deprecated)
+#else
+    #define NOTE_ARDUINO_DEPRECATED
+    #define NOTE_ARDUINO_NO_DEPRECATED_ATTR
+#endif // __GNUC__ || __clang__
+
 /**************************************************************************/
 /*!
     @brief  Class that stores state and functions for interacting with the
@@ -83,8 +92,8 @@ public:
     }
     bool debugSyncStatus(int pollFrequencyMs, int maxLevel);
     void deleteResponse(J *rsp);
-    void logDebug(const char *message);
-    void logDebugf(const char *format, ...);
+    NOTE_ARDUINO_DEPRECATED void logDebug(const char *message);
+    NOTE_ARDUINO_DEPRECATED void logDebugf(const char *format, ...);
     J *newCommand(const char *request);
     J *newRequest(const char *request);
     J *requestAndResponse(J *req);

--- a/test/run_all_tests.sh
+++ b/test/run_all_tests.sh
@@ -11,9 +11,13 @@ all_tests_result=0
 # host machine is running Fedora. See https://stackoverflow.com/a/75293014.
 ulimit -n 1024
 
+# Note that we use -Wno-deprecated-declarations in the compilation commands
+# below because we have deprecated some note-arduino functions (e.g. logDebug),
+# but we still have unit tests for them.
+
 if [ 0 -eq $all_tests_result ]; then
   echo && echo -e "${YELLOW}Compiling and running Notecard Test Suite...${DEFAULT}"
-  g++ -fprofile-arcs -ftest-coverage -Wall -Wextra -Werror -Wpedantic -std=c++11 -O0 -g \
+  g++ -fprofile-arcs -ftest-coverage -Wall -Wextra -Werror -Wpedantic -Wno-deprecated-declarations -std=c++11 -O0 -g \
     src/Notecard.cpp \
     test/Notecard.test.cpp \
     test/mock/mock-arduino.cpp \
@@ -43,7 +47,7 @@ fi
 
 if [ 0 -eq $all_tests_result ]; then
   echo && echo -e "${YELLOW}Compiling and running NoteI2c_Arduino Test Suite (no flags)...${DEFAULT}"
-  g++ -fprofile-arcs -ftest-coverage -Wall -Wextra -Werror -Wpedantic -std=c++11 -O0 -g \
+  g++ -fprofile-arcs -ftest-coverage -Wall -Wextra -Werror -Wpedantic -Wno-deprecated-declarations -std=c++11 -O0 -g \
     src/NoteI2c_Arduino.cpp \
     test/NoteI2c_Arduino.test.cpp \
     test/mock/mock-arduino.cpp \
@@ -67,7 +71,7 @@ fi
 
 if [ 0 -eq $all_tests_result ]; then
   echo && echo -e "${YELLOW}Compiling and running NoteI2c_Arduino Test Suite (-DWIRE_HAS_END)...${DEFAULT}"
-  g++ -fprofile-arcs -ftest-coverage -Wall -Wextra -Werror -Wpedantic -std=c++11 -O0 -g \
+  g++ -fprofile-arcs -ftest-coverage -Wall -Wextra -Werror -Wpedantic -Wno-deprecated-declarations -std=c++11 -O0 -g \
     src/NoteI2c_Arduino.cpp \
     test/NoteI2c_Arduino.test.cpp \
     test/mock/mock-arduino.cpp \
@@ -92,7 +96,7 @@ fi
 
 if [ 0 -eq $all_tests_result ]; then
   echo && echo -e "${YELLOW}Compiling and running NoteLog_Arduino Test Suite...${DEFAULT}"
-  g++ -fprofile-arcs -ftest-coverage -Wall -Wextra -Werror -Wpedantic -std=c++11 -O0 -g \
+  g++ -fprofile-arcs -ftest-coverage -Wall -Wextra -Werror -Wpedantic -Wno-deprecated-declarations -std=c++11 -O0 -g \
     src/NoteLog_Arduino.cpp \
     test/NoteLog_Arduino.test.cpp \
     test/mock/mock-arduino.cpp \
@@ -116,7 +120,7 @@ fi
 
 if [ 0 -eq $all_tests_result ]; then
   echo && echo -e "${YELLOW}Compiling and running NoteSerial_Arduino Test Suite...${DEFAULT}"
-  g++ -fprofile-arcs -ftest-coverage -Wall -Wextra -Werror -Wpedantic -std=c++11 -O0 -g \
+  g++ -fprofile-arcs -ftest-coverage -Wall -Wextra -Werror -Wpedantic -Wno-deprecated-declarations -std=c++11 -O0 -g \
     src/NoteSerial_Arduino.cpp \
     test/NoteSerial_Arduino.test.cpp \
     test/mock/mock-arduino.cpp \
@@ -140,7 +144,7 @@ fi
 
 if [ 0 -eq $all_tests_result ]; then
   echo && echo -e "${YELLOW}Compiling and running NoteTxn_Arduino Test Suite...${DEFAULT}"
-  g++ -fprofile-arcs -ftest-coverage -Wall -Wextra -Werror -Wpedantic -std=c++11 -O0 -g \
+  g++ -fprofile-arcs -ftest-coverage -Wall -Wextra -Werror -Wpedantic -Wno-deprecated-declarations -std=c++11 -O0 -g \
     src/NoteTxn_Arduino.cpp \
     test/NoteTxn_Arduino.test.cpp \
     test/mock/mock-arduino.cpp \


### PR DESCRIPTION
These are wrappers around NoteDebug, which is really intended for internal note-c usage only. As such, we don't want users calling these functions.