### PR TITLE
chore: Create `NoteDefines.h`

### DIFF
--- a/src/NoteDefines.h
+++ b/src/NoteDefines.h
@@ -1,0 +1,21 @@
+#ifndef NOTE_DEFINES_H
+#define NOTE_DEFINES_H
+
+// Define the version of the `note-arduino` library
+#define NOTE_ARDUINO_VERSION_MAJOR 1
+#define NOTE_ARDUINO_VERSION_MINOR 6
+#define NOTE_ARDUINO_VERSION_PATCH 3
+
+#define NOTE_ARDUINO_VERSION NOTE_C_STRINGIZE(NOTE_ARDUINO_VERSION_MAJOR) "." NOTE_C_STRINGIZE(NOTE_ARDUINO_VERSION_MINOR) "." NOTE_C_STRINGIZE(NOTE_ARDUINO_VERSION_PATCH)
+
+// Unified attribute for marking functions as deprecated
+#if defined(__GNUC__) | defined(__clang__)
+    #define NOTE_ARDUINO_DEPRECATED __attribute__((__deprecated__))
+#elif defined(_MSC_VER)
+    #define NOTE_ARDUINO_DEPRECATED __declspec(deprecated)
+#else
+    #define NOTE_ARDUINO_DEPRECATED
+    #define NOTE_ARDUINO_NO_DEPRECATED_ATTR
+#endif // __GNUC__ || __clang__
+
+#endif // NOTE_DEFINES_H

--- a/src/Notecard.h
+++ b/src/Notecard.h
@@ -27,6 +27,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "NoteDefines.h"
 #include "NoteI2c.hpp"
 #include "NoteLog.hpp"
 #include "NoteSerial.hpp"
@@ -44,21 +45,6 @@
 #include "mock/mock-arduino.hpp"
 #include "mock/mock-parameters.hpp"
 #endif
-
-#define NOTE_ARDUINO_VERSION_MAJOR 1
-#define NOTE_ARDUINO_VERSION_MINOR 6
-#define NOTE_ARDUINO_VERSION_PATCH 3
-
-#define NOTE_ARDUINO_VERSION NOTE_C_STRINGIZE(NOTE_ARDUINO_VERSION_MAJOR) "." NOTE_C_STRINGIZE(NOTE_ARDUINO_VERSION_MINOR) "." NOTE_C_STRINGIZE(NOTE_ARDUINO_VERSION_PATCH)
-
-#if defined(__GNUC__) | defined(__clang__)
-    #define NOTE_ARDUINO_DEPRECATED __attribute__((__deprecated__))
-#elif defined(_MSC_VER)
-    #define NOTE_ARDUINO_DEPRECATED __declspec(deprecated)
-#else
-    #define NOTE_ARDUINO_DEPRECATED
-    #define NOTE_ARDUINO_NO_DEPRECATED_ATTR
-#endif // __GNUC__ || __clang__
 
 /**************************************************************************/
 /*!


### PR DESCRIPTION
Allows `#define`s to be shared across compilation units