### PR TITLE
fix: reduce current usage on STM32-based hosts when using TXNs

### DIFF
--- a/src/NoteTxn_Arduino.cpp
+++ b/src/NoteTxn_Arduino.cpp
@@ -56,8 +56,13 @@ NoteTxn_Arduino::NoteTxn_Arduino
     _rtx_pin(rtx_pin_)
 {
     // Float CTX/RTX to conserve energy
+#ifdef ARDUINO_ARCH_STM32
+    ::pinMode(_ctx_pin, INPUT_ANALOG);
+    ::pinMode(_rtx_pin, INPUT_ANALOG);
+#else
     ::pinMode(_ctx_pin, INPUT);
     ::pinMode(_rtx_pin, INPUT);
+#endif
 }
 
 bool
@@ -84,7 +89,11 @@ NoteTxn_Arduino::start (
     }
 
     // Float CTX to conserve energy
+#ifdef ARDUINO_ARCH_STM32
+    ::pinMode(_ctx_pin, INPUT_ANALOG);
+#else
     ::pinMode(_ctx_pin, INPUT);
+#endif
 
     // Abandon request on timeout
     if (!result) {
@@ -100,7 +109,11 @@ NoteTxn_Arduino::stop (
 )
 {
     // Float RTX pin
+#ifdef ARDUINO_ARCH_STM32
+    ::pinMode(_rtx_pin, INPUT_ANALOG);
+#else
     ::pinMode(_rtx_pin, INPUT);
+#endif
 }
 
 // Explicitly instantiate the template function for array types


### PR DESCRIPTION
When using transactions (for example, when talking to a NOTE-ESP) this library must initialize and uninitialize GPIOs for RTX and CTX.

For system current usage reasons - particularly, if the sketch is using the Low Power library - it is important that we don't put IO pins with no pullups or pulldowns into an ambiguous GPIO state that will cause excessive current draw.

This PR leverages the STM32's ability to actually put a pin into a floating state with no leakage.