### PR TITLE
feat: add Notecard ping

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ For I2C, you may simply call Notecard `begin()` with no parameters.
 notecard.begin();
 ```
 
+### Checking Connectivity
+
+After calling `begin()`, `ping()` can verify that the Notecard is reachable.
+On serial transports, it also attempts to recover from a baud-rate mismatch
+by scanning common Notecard rates and, when connected on AUX, reconfiguring
+the Notecard to the baud rate passed to `begin()`.
+
 ### Sending Notecard Requests
 
 Notecard requests use bundled `J` json package to allocate a `req`, is a JSON

--- a/keywords.txt
+++ b/keywords.txt
@@ -14,6 +14,7 @@ deleteResponse			KEYWORD2
 end				KEYWORD2
 newCommand			KEYWORD2
 newRequest			KEYWORD2
+ping				KEYWORD2
 requestAndResponse		KEYWORD2
 requestAndResponseWithRetry	KEYWORD2
 responseError			KEYWORD2

--- a/src/NoteSerial.hpp
+++ b/src/NoteSerial.hpp
@@ -47,6 +47,36 @@ public:
     */
     /**************************************************************************/
     virtual size_t transmit(uint8_t * buffer, size_t size, bool flush) = 0;
+
+    /**************************************************************************/
+    /*!
+        @brief  Change the baud rate of the host Serial port.
+
+        Reconfigures the underlying platform Serial interface to operate at
+        the specified baud rate, and updates the cached rate used by `reset()`
+        so a subsequent reset restores to the new rate. Implementations that
+        cannot change the rate at runtime may return `false`.
+
+        @param rate  The new baud rate, in bits per second.
+        @return `true` on success, `false` if the rate change is unsupported
+                or failed.
+    */
+    /**************************************************************************/
+    virtual bool setBaudRate(size_t rate) {
+        (void)rate;
+        return false;
+    }
+
+    /**************************************************************************/
+    /*!
+        @brief  Get the currently-configured baud rate of the host Serial port.
+        @return The active baud rate, in bits per second. Implementations that
+                do not track a rate may return 0.
+    */
+    /**************************************************************************/
+    virtual size_t getBaudRate(void) const {
+        return 0;
+    }
 };
 
 /******************************************************************************/

--- a/src/NoteSerial.hpp
+++ b/src/NoteSerial.hpp
@@ -62,7 +62,7 @@ public:
                 or failed.
     */
     /**************************************************************************/
-    virtual bool setBaudRate(size_t rate) {
+    virtual bool setBaudRate(uint32_t rate) {
         (void)rate;
         return false;
     }
@@ -74,7 +74,7 @@ public:
                 do not track a rate may return 0.
     */
     /**************************************************************************/
-    virtual size_t getBaudRate(void) const {
+    virtual uint32_t getBaudRate(void) const {
         return 0;
     }
 };

--- a/src/NoteSerial_Arduino.cpp
+++ b/src/NoteSerial_Arduino.cpp
@@ -129,6 +129,36 @@ NoteSerial_Arduino<T>::transmit (
     return result;
 }
 
+template <typename T>
+bool
+NoteSerial_Arduino<T>::setBaudRate (
+    size_t rate
+)
+{
+    _notecardSerial.end();
+    _notecardSerial.begin(rate);
+    _notecardSerialSpeed = rate;
+
+    // Wait for the serial port to be ready, matching the constructor's
+    // handling for native-USB boards where the Serial object becomes
+    // truthy only after the USB CDC link is up.
+    for (const size_t startMs = NoteGetMs()
+       ; !_notecardSerial && ((NoteGetMs() - startMs) < NOTE_C_SERIAL_TIMEOUT_MS)
+       ;
+    );
+
+    return true;
+}
+
+template <typename T>
+size_t
+NoteSerial_Arduino<T>::getBaudRate (
+    void
+) const
+{
+    return (size_t)_notecardSerialSpeed;
+}
+
 // Explicitly instantiate the classes and methods for the supported types
 template class NoteSerial_Arduino<HardwareSerial>;
 template NoteSerial * make_note_serial<MakeNoteSerial_ArduinoParameters<HardwareSerial>>(MakeNoteSerial_ArduinoParameters<HardwareSerial> &);

--- a/src/NoteSerial_Arduino.cpp
+++ b/src/NoteSerial_Arduino.cpp
@@ -61,7 +61,7 @@ template <typename T>
 NoteSerial_Arduino<T>::NoteSerial_Arduino
 (
     T & serial_,
-    size_t baud_rate_
+    uint32_t baud_rate_
 ) :
     _notecardSerial(serial_),
     _notecardSerialSpeed(baud_rate_)
@@ -132,7 +132,7 @@ NoteSerial_Arduino<T>::transmit (
 template <typename T>
 bool
 NoteSerial_Arduino<T>::setBaudRate (
-    size_t rate
+    uint32_t rate
 )
 {
     _notecardSerial.end();
@@ -151,12 +151,12 @@ NoteSerial_Arduino<T>::setBaudRate (
 }
 
 template <typename T>
-size_t
+uint32_t
 NoteSerial_Arduino<T>::getBaudRate (
     void
 ) const
 {
-    return (size_t)_notecardSerialSpeed;
+    return _notecardSerialSpeed;
 }
 
 // Explicitly instantiate the classes and methods for the supported types

--- a/src/NoteSerial_Arduino.hpp
+++ b/src/NoteSerial_Arduino.hpp
@@ -32,10 +32,14 @@ public:
     char receive(void) override;
     bool reset(void) override;
     size_t transmit(uint8_t * buffer, size_t size, bool flush) override;
+    bool setBaudRate(size_t rate) override;
+    size_t getBaudRate(void) const override;
 
 private:
     T & _notecardSerial;
-    const int _notecardSerialSpeed;
+    // Not `const`: `setBaudRate()` mutates this so `reset()` restores to the
+    // currently-active rate rather than whatever was passed at construction.
+    int _notecardSerialSpeed;
 };
 
 #endif // NOTE_SERIAL_ARDUINO_HPP

--- a/src/NoteSerial_Arduino.hpp
+++ b/src/NoteSerial_Arduino.hpp
@@ -13,33 +13,33 @@ template <typename T>
 struct MakeNoteSerial_ArduinoParameters {
     MakeNoteSerial_ArduinoParameters (
         T & serial_,
-        size_t baud_rate_
+        uint32_t baud_rate_
     ) :
         serial(serial_),
         baud_rate(baud_rate_)
     { }
     T & serial;
-    size_t baud_rate;
+    uint32_t baud_rate;
 };
 
 template <typename T>
 class NoteSerial_Arduino final : public NoteSerial
 {
 public:
-    NoteSerial_Arduino(T & serial_, size_t baud_rate_);
+    NoteSerial_Arduino(T & serial_, uint32_t baud_rate_);
     ~NoteSerial_Arduino(void);
     size_t available(void) override;
     char receive(void) override;
     bool reset(void) override;
     size_t transmit(uint8_t * buffer, size_t size, bool flush) override;
-    bool setBaudRate(size_t rate) override;
-    size_t getBaudRate(void) const override;
+    bool setBaudRate(uint32_t rate) override;
+    uint32_t getBaudRate(void) const override;
 
 private:
     T & _notecardSerial;
     // Not `const`: `setBaudRate()` mutates this so `reset()` restores to the
     // currently-active rate rather than whatever was passed at construction.
-    int _notecardSerialSpeed;
+    uint32_t _notecardSerialSpeed;
 };
 
 #endif // NOTE_SERIAL_ARDUINO_HPP

--- a/src/Notecard.cpp
+++ b/src/Notecard.cpp
@@ -278,6 +278,11 @@ NOTE_ARDUINO_DEPRECATED void Notecard::logDebugf(const char *format, ...) const
     NoteDebug(message);
 }
 
+NoteSerial *Notecard::getNoteSerial(void) const
+{
+    return noteSerial;
+}
+
 J *Notecard::newCommand(const char *request) const
 {
     return NoteNewCommand(request);

--- a/src/Notecard.h
+++ b/src/Notecard.h
@@ -368,6 +368,39 @@ public:
 
     /**************************************************************************/
     /*!
+        @brief  Ping the Notecard to verify that it is reachable, negotiating
+                the serial baud rate if necessary.
+
+        On I2C, this simply pings the Notecard with a fast connectivity check.
+
+        On Serial, the behavior is:
+          1. Ping the Notecard at the currently-configured host UART rate.
+             If it responds, return `true`.
+          2. Otherwise, assume this may be the Notecard's AUX serial port at
+             an unknown rate. Scan through known rates (115200, 230400, 460800,
+             921600, 9600) to discover the current Notecard rate. If none
+             succeed, restore the original host UART rate and return `false`.
+          3. If a rate was found, query `card.io` to determine which physical
+             port we are connected to. If it is not the AUX port, comms are
+             working; return `true` with the host UART left at the discovered
+             rate. Note that in this case the host UART may differ from the
+             rate passed to `begin()` — there is no way to change the rate of
+             non-AUX ports.
+          4. If it is the AUX port, issue `card.aux.serial` to reconfigure the
+             AUX port to the rate originally passed to `begin()`. On success,
+             switch the host UART to match, verify with a final ping, and
+             return the result. On failure, leave the host UART at the
+             discovered rate (so the caller can still reach the Notecard) and
+             return `false`.
+
+        @return `true` if the Notecard is reachable at the end of the call,
+                `false` otherwise.
+    */
+    /**************************************************************************/
+    bool ping(void);
+
+    /**************************************************************************/
+    /*!
         @brief  Sends a request to the Notecard.
 
         This function takes a populated `J` JSON request object and sends
@@ -490,6 +523,12 @@ public:
 
 private:
     void platformInit (bool assignCallbacks);
+
+    // Accessor for the Notecard's NoteSerial singleton. Defined in
+    // Notecard.cpp where the anonymous-namespace-scoped singleton is
+    // visible; used by ping() (in NotecardPing.cpp) to manipulate the
+    // host UART baud rate during AUX-port negotiation.
+    NoteSerial *getNoteSerial(void) const;
 };
 
 #endif

--- a/src/NotecardPing.cpp
+++ b/src/NotecardPing.cpp
@@ -1,0 +1,260 @@
+/*!
+ * @file NotecardPing.cpp
+ *
+ * Implementation of `Notecard::ping()` — ping the Notecard to verify
+ * reachability and, on a serial link, negotiate the AUX port's baud rate
+ * to match the rate passed to `Notecard::begin()` if necessary.
+ *
+ * Written by Ray Ozzie and Blues Inc. team.
+ *
+ * Copyright (c) 2019 Blues Inc. MIT License. Use of this source code is
+ * governed by licenses granted by the copyright holder including that found in
+ * the
+ * <a href="https://github.com/blues/note-arduino/blob/master/LICENSE">LICENSE</a>
+ * file.
+ */
+
+#include "Notecard.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#ifndef NOTE_MOCK
+#include <note-c/note.h>
+#else
+#include "mock/mock-arduino.hpp"
+#include "mock/mock-parameters.hpp"
+#endif
+
+// Local formatting helpers that route through note-c's level-filtered log
+// macros. The standard NOTE_C_LOG_* macros accept only literal/string-pointer
+// arguments, so we format into a stack buffer first and then pass it through.
+// This keeps ping() output consistent with logging elsewhere in note-c and
+// still honors runtime log-level filtering via NoteSetLogLevel().
+#define PING_LOG_BUF_LEN 96
+
+#define PING_LOG_INFO(...) do {                                     \
+    char _pingBuf[PING_LOG_BUF_LEN];                                \
+    snprintf(_pingBuf, sizeof(_pingBuf), __VA_ARGS__);              \
+    NOTE_C_LOG_INFO(_pingBuf);                                      \
+} while (0)
+
+#define PING_LOG_WARN(...) do {                                     \
+    char _pingBuf[PING_LOG_BUF_LEN];                                \
+    snprintf(_pingBuf, sizeof(_pingBuf), __VA_ARGS__);              \
+    NOTE_C_LOG_WARN(_pingBuf);                                      \
+} while (0)
+
+#define PING_LOG_DEBUG(...) do {                                    \
+    char _pingBuf[PING_LOG_BUF_LEN];                                \
+    snprintf(_pingBuf, sizeof(_pingBuf), __VA_ARGS__);              \
+    NOTE_C_LOG_DEBUG(_pingBuf);                                     \
+} while (0)
+
+namespace
+{
+
+// Baud rates to scan when the initial ping fails on a serial link. Ordered
+// by prevalence on modern Notecard deployments: higher rates first (most
+// common for aux-port configurations), then 9600 as the legacy default.
+//
+// The caller's desired rate is skipped during the scan because it was
+// already tried by the initial ping at the top of ping().
+const uint32_t kScanBaudRates[] = {
+    115200,
+    230400,
+    460800,
+    921600,
+    9600,
+};
+const size_t kScanBaudRateCount = sizeof(kScanBaudRates) / sizeof(kScanBaudRates[0]);
+
+// Small settling delay after receiving the response to `card.aux.serial`
+// before switching the host UART to the new rate. The Notecard sends the
+// response at the old rate and then commits the new rate; this pause lets
+// the final bytes clear the wire before we switch.
+const uint32_t kAuxSerialSettleMs = 20;
+
+// After switching the host UART to the new rate, the Notecard may need a
+// brief period to fully initialize its port at the new rate before it can
+// service a fresh request. We retry the verification ping up to
+// kPostReconfigPingAttempts times with kPostReconfigPingDelayMs between
+// attempts to accommodate this.
+const uint8_t  kPostReconfigPingAttempts = 5;
+const uint32_t kPostReconfigPingDelayMs  = 250;
+
+} // namespace
+
+bool Notecard::ping(void)
+{
+    // I2C: the baud rate is meaningless on I2C, so just ping for
+    // connectivity to catch wiring/address problems and return the result.
+    if (NoteGetActiveInterface() == NOTE_C_INTERFACE_I2C) {
+        NOTE_C_LOG_DEBUG("ping: starting (i2c)");
+        const bool ok = NotePing();
+        if (ok) {
+            NOTE_C_LOG_INFO("ping: Notecard reachable over i2c");
+        } else {
+            NOTE_C_LOG_WARN("ping: Notecard unreachable over i2c");
+        }
+        return ok;
+    }
+
+    // Serial: must have a NoteSerial singleton to proceed.
+    NoteSerial *ns = getNoteSerial();
+    if (ns == nullptr) {
+        NOTE_C_LOG_WARN("ping: no NoteSerial singleton (did you call Notecard::begin?)");
+        return false;
+    }
+
+    const size_t desiredRate = ns->getBaudRate();
+    PING_LOG_DEBUG("ping: starting (serial, %lu baud)", (unsigned long)desiredRate);
+
+    // Step 1: ping at the currently-configured host UART rate. If the
+    // Notecard is already reachable, we are done and nothing else changes.
+    if (NotePing()) {
+        PING_LOG_INFO("ping: Notecard reachable at %lu baud", (unsigned long)desiredRate);
+        return true;
+    }
+
+    PING_LOG_INFO("ping: initial probe at %lu baud failed; scanning baud rates",
+                  (unsigned long)desiredRate);
+
+    // Step 2: scan through the known aux-port rates looking for one at
+    // which the Notecard will talk to us. The desired rate is skipped
+    // because it was already tried by the initial ping above. On
+    // success, the host UART is left at the discovered rate (i.e.,
+    // whatever `ns->setBaudRate` was last called with) and we fall
+    // through to step 3.
+    bool found = false;
+    size_t discoveredRate = 0;
+    for (size_t i = 0; i < kScanBaudRateCount; ++i) {
+        const size_t rate = kScanBaudRates[i];
+        if (rate == desiredRate) {
+            continue;
+        }
+        PING_LOG_DEBUG("ping: trying %lu baud", (unsigned long)rate);
+        if (!ns->setBaudRate(rate)) {
+            // Implementation can't change baud rate at runtime — nothing we
+            // can do but give up.
+            NOTE_C_LOG_WARN("ping: host Serial does not support runtime baud rate change");
+            return false;
+        }
+        if (NotePing()) {
+            found = true;
+            discoveredRate = rate;
+            break;
+        }
+    }
+
+    if (!found) {
+        // Couldn't reach the Notecard at any scanned rate. Restore the
+        // host UART to the caller's originally-requested rate and fail.
+        PING_LOG_WARN("ping: no response at any scanned rate; restoring host UART to %lu baud",
+                      (unsigned long)desiredRate);
+        ns->setBaudRate(desiredRate);
+        return false;
+    }
+
+    PING_LOG_INFO("ping: found Notecard at %lu baud", (unsigned long)discoveredRate);
+
+    // Step 3: comms is working at the discovered rate. Query `card.io` with
+    // mode:"port" to determine whether we are on the aux port or on a
+    // non-configurable port (e.g., usb, notecard).
+    J *req = NoteNewRequest("card.io");
+    if (req == nullptr) {
+        NOTE_C_LOG_WARN("ping: failed to allocate card.io request");
+        return false;
+    }
+    JAddStringToObject(req, "mode", "port");
+    J *rsp = NoteRequestResponse(req);
+    if (rsp == nullptr) {
+        NOTE_C_LOG_WARN("ping: card.io request failed");
+        return false;
+    }
+    const bool ioHasErr = !JIsNullString(rsp, "err");
+    const char *portStatus = JGetString(rsp, "status");
+    const bool isAux = (strcmp(portStatus, "aux") == 0);
+    PING_LOG_INFO("ping: card.io reports port '%s'", portStatus);
+    JDelete(rsp);
+
+    if (ioHasErr) {
+        // Unexpected: NotePing proved connectivity at the discovered rate,
+        // but card.io returned an error. We cannot determine which port
+        // we are on, so we cannot safely reconfigure. Return false and
+        // leave the host UART at the discovered rate.
+        NOTE_C_LOG_WARN("ping: card.io returned an error; aborting");
+        return false;
+    }
+
+    if (!isAux) {
+        // Connected to a non-aux port (e.g., usb or notecard). Its rate
+        // cannot be changed, so the host UART is correctly set to the
+        // discovered rate and comms is working. Return true even though
+        // the host UART may differ from what was passed to begin().
+        PING_LOG_INFO("ping: non-aux port; host UART stays at %lu baud",
+                      (unsigned long)discoveredRate);
+        return true;
+    }
+
+    // Step 4: aux port confirmed. Reconfigure it to the desired rate.
+    PING_LOG_INFO("ping: reconfiguring aux port from %lu to %lu baud",
+                  (unsigned long)discoveredRate, (unsigned long)desiredRate);
+    req = NoteNewRequest("card.aux.serial");
+    if (req == nullptr) {
+        NOTE_C_LOG_WARN("ping: failed to allocate card.aux.serial request");
+        return false;
+    }
+    JAddStringToObject(req, "mode", "req");
+    JAddIntToObject(req, "rate", (JINTEGER)desiredRate);
+    rsp = NoteRequestResponse(req);
+    if (rsp == nullptr) {
+        // Transport failure. Host UART stays at the discovered rate so
+        // the caller can still reach the Notecard.
+        PING_LOG_WARN("ping: card.aux.serial request failed; host UART remains at %lu baud",
+                      (unsigned long)discoveredRate);
+        return false;
+    }
+    const bool auxErr = !JIsNullString(rsp, "err");
+    JDelete(rsp);
+    if (auxErr) {
+        // Notecard rejected the rate change. Host UART stays at the
+        // discovered rate (per the design decision for option (a)) so
+        // the caller can still reach the Notecard.
+        PING_LOG_WARN("ping: aux rate change rejected; host UART remains at %lu baud",
+                      (unsigned long)discoveredRate);
+        return false;
+    }
+
+    // Response was received at the old (discovered) rate; the Notecard
+    // has now committed to desiredRate. Let residual bytes clear the
+    // wire, then switch the host UART to match.
+    NoteDelayMs(kAuxSerialSettleMs);
+    if (!ns->setBaudRate(desiredRate)) {
+        NOTE_C_LOG_WARN("ping: failed to switch host UART after aux reconfig");
+        return false;
+    }
+
+    // Verify with a retry loop. The Notecard may need a short initialization
+    // period after committing to the new aux-port rate before it can service
+    // a fresh request; a single probe is not reliable here.
+    for (uint8_t attempt = 1; attempt <= kPostReconfigPingAttempts; ++attempt) {
+        if (NotePing()) {
+            PING_LOG_INFO("ping: aux port now at %lu baud; verified (attempt %u)",
+                          (unsigned long)desiredRate, (unsigned)attempt);
+            return true;
+        }
+        if (attempt < kPostReconfigPingAttempts) {
+            PING_LOG_DEBUG("ping: post-reconfig probe %u/%u failed; retrying in %lu ms",
+                           (unsigned)attempt,
+                           (unsigned)kPostReconfigPingAttempts,
+                           (unsigned long)kPostReconfigPingDelayMs);
+            NoteDelayMs(kPostReconfigPingDelayMs);
+        }
+    }
+
+    PING_LOG_WARN("ping: verification at %lu baud failed after %u attempts",
+                  (unsigned long)desiredRate,
+                  (unsigned)kPostReconfigPingAttempts);
+    return false;
+}

--- a/src/NotecardPing.cpp
+++ b/src/NotecardPing.cpp
@@ -83,6 +83,23 @@ const uint32_t kAuxSerialSettleMs = 20;
 const uint8_t  kPostReconfigPingAttempts = 5;
 const uint32_t kPostReconfigPingDelayMs  = 250;
 
+bool pingNotecard(void)
+{
+    J *req = NoteNewRequest("card.version");
+    if (req == nullptr) {
+        return false;
+    }
+
+    J *rsp = NoteRequestResponse(req);
+    if (rsp == nullptr) {
+        return false;
+    }
+
+    const bool ok = !NoteResponseError(rsp);
+    NoteDeleteResponse(rsp);
+    return ok;
+}
+
 } // namespace
 
 bool Notecard::ping(void)
@@ -91,7 +108,7 @@ bool Notecard::ping(void)
     // connectivity to catch wiring/address problems and return the result.
     if (NoteGetActiveInterface() == NOTE_C_INTERFACE_I2C) {
         NOTE_C_LOG_DEBUG("ping: starting (i2c)");
-        const bool ok = NotePing();
+        const bool ok = pingNotecard();
         if (ok) {
             NOTE_C_LOG_INFO("ping: Notecard reachable over i2c");
         } else {
@@ -107,12 +124,12 @@ bool Notecard::ping(void)
         return false;
     }
 
-    const size_t desiredRate = ns->getBaudRate();
+    const uint32_t desiredRate = ns->getBaudRate();
     PING_LOG_DEBUG("ping: starting (serial, %lu baud)", (unsigned long)desiredRate);
 
     // Step 1: ping at the currently-configured host UART rate. If the
     // Notecard is already reachable, we are done and nothing else changes.
-    if (NotePing()) {
+    if (pingNotecard()) {
         PING_LOG_INFO("ping: Notecard reachable at %lu baud", (unsigned long)desiredRate);
         return true;
     }
@@ -127,9 +144,9 @@ bool Notecard::ping(void)
     // whatever `ns->setBaudRate` was last called with) and we fall
     // through to step 3.
     bool found = false;
-    size_t discoveredRate = 0;
+    uint32_t discoveredRate = 0;
     for (size_t i = 0; i < kScanBaudRateCount; ++i) {
-        const size_t rate = kScanBaudRates[i];
+        const uint32_t rate = kScanBaudRates[i];
         if (rate == desiredRate) {
             continue;
         }
@@ -140,7 +157,7 @@ bool Notecard::ping(void)
             NOTE_C_LOG_WARN("ping: host Serial does not support runtime baud rate change");
             return false;
         }
-        if (NotePing()) {
+        if (pingNotecard()) {
             found = true;
             discoveredRate = rate;
             break;
@@ -172,11 +189,11 @@ bool Notecard::ping(void)
         NOTE_C_LOG_WARN("ping: card.io request failed");
         return false;
     }
-    const bool ioHasErr = !JIsNullString(rsp, "err");
+    const bool ioHasErr = NoteResponseError(rsp);
     const char *portStatus = JGetString(rsp, "status");
     const bool isAux = (strcmp(portStatus, "aux") == 0);
     PING_LOG_INFO("ping: card.io reports port '%s'", portStatus);
-    JDelete(rsp);
+    NoteDeleteResponse(rsp);
 
     if (ioHasErr) {
         // Unexpected: NotePing proved connectivity at the discovered rate,
@@ -215,8 +232,8 @@ bool Notecard::ping(void)
                       (unsigned long)discoveredRate);
         return false;
     }
-    const bool auxErr = !JIsNullString(rsp, "err");
-    JDelete(rsp);
+    const bool auxErr = NoteResponseError(rsp);
+    NoteDeleteResponse(rsp);
     if (auxErr) {
         // Notecard rejected the rate change. Host UART stays at the
         // discovered rate (per the design decision for option (a)) so
@@ -239,7 +256,7 @@ bool Notecard::ping(void)
     // period after committing to the new aux-port rate before it can service
     // a fresh request; a single probe is not reliable here.
     for (uint8_t attempt = 1; attempt <= kPostReconfigPingAttempts; ++attempt) {
-        if (NotePing()) {
+        if (pingNotecard()) {
             PING_LOG_INFO("ping: aux port now at %lu baud; verified (attempt %u)",
                           (unsigned long)desiredRate, (unsigned)attempt);
             return true;

--- a/test/NoteSerial_Arduino.test.cpp
+++ b/test/NoteSerial_Arduino.test.cpp
@@ -150,6 +150,34 @@ int test_noteserial_arduino_constructor_does_not_modify_baud_parameter_before_pa
     return result;
 }
 
+int test_noteserial_arduino_constructor_preserves_high_baud_rate()
+{
+    int result;
+
+    // Arrange
+    const uint32_t EXPECTED_BAUD_RATE = 460800;
+
+    hardwareSerialBegin_Parameters.reset();
+
+    // Action
+    NoteSerial_Arduino<HardwareSerial> noteserial(Serial, EXPECTED_BAUD_RATE);
+
+    // Assert
+    if (EXPECTED_BAUD_RATE == hardwareSerialBegin_Parameters.baud)
+    {
+        result = 0;
+    }
+    else
+    {
+        result = static_cast<int>('s' + 'e' + 'r' + 'i' + 'a' + 'l');
+        std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
+        std::cout << "\thardwareSerialBegin_Parameters.baud == " << hardwareSerialBegin_Parameters.baud << ", EXPECTED: " << EXPECTED_BAUD_RATE << std::endl;
+        std::cout << "[";
+    }
+
+    return result;
+}
+
 int test_noteserial_arduino_deconstructor_invokes_hardware_serial_end_method()
 {
     int result;
@@ -571,6 +599,36 @@ int test_noteserial_arduino_transmit_does_not_modify_hardware_serial_write_resul
     return result;
 }
 
+int test_noteserial_arduino_setBaudRate_updates_rate_used_by_reset()
+{
+    int result;
+
+    // Arrange
+    const uint32_t EXPECTED_BAUD_RATE = 460800;
+    NoteSerial_Arduino<HardwareSerial> noteserial(Serial, 9600);
+
+    hardwareSerialBegin_Parameters.reset();
+
+    // Action
+    noteserial.setBaudRate(EXPECTED_BAUD_RATE);
+    noteserial.reset();
+
+    // Assert
+    if (EXPECTED_BAUD_RATE == hardwareSerialBegin_Parameters.baud)
+    {
+        result = 0;
+    }
+    else
+    {
+        result = static_cast<int>('s' + 'e' + 'r' + 'i' + 'a' + 'l');
+        std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
+        std::cout << "\thardwareSerialBegin_Parameters.baud == " << hardwareSerialBegin_Parameters.baud << ", EXPECTED: " << EXPECTED_BAUD_RATE << std::endl;
+        std::cout << "[";
+    }
+
+    return result;
+}
+
 int main(void)
 {
     TestFunction tests[] = {
@@ -579,6 +637,7 @@ int main(void)
         {test_make_note_serial_deletes_singleton_when_nullptr_is_passed_as_parameter, "test_make_note_serial_deletes_singleton_when_nullptr_is_passed_as_parameter"},
         {test_noteserial_arduino_constructor_invokes_hardware_serial_parameter_begin_method, "test_noteserial_arduino_constructor_invokes_hardware_serial_parameter_begin_method"},
         {test_noteserial_arduino_constructor_does_not_modify_baud_parameter_before_passing_to_hardware_serial_begin, "test_noteserial_arduino_constructor_does_not_modify_baud_parameter_before_passing_to_hardware_serial_begin"},
+        {test_noteserial_arduino_constructor_preserves_high_baud_rate, "test_noteserial_arduino_constructor_preserves_high_baud_rate"},
         {test_noteserial_arduino_deconstructor_invokes_hardware_serial_end_method, "test_noteserial_arduino_deconstructor_invokes_hardware_serial_end_method"},
         {test_noteserial_arduino_available_invokes_hardware_serial_available, "test_noteserial_arduino_available_invokes_hardware_serial_available"},
         {test_noteserial_arduino_available_does_not_modify_hardware_serial_available_result_value_before_returning_to_caller, "test_noteserial_arduino_available_does_not_modify_hardware_serial_available_result_value_before_returning_to_caller"},
@@ -593,7 +652,8 @@ int main(void)
         {test_noteserial_arduino_transmit_does_not_modify_size_parameter_value_before_passing_to_hardware_serial_write, "test_noteserial_arduino_transmit_does_not_modify_size_parameter_value_before_passing_to_hardware_serial_write"},
         {test_noteserial_arduino_transmit_invokes_hardware_serial_flush_when_flush_parameter_is_true, "test_noteserial_arduino_transmit_invokes_hardware_serial_flush_when_flush_parameter_is_true"},
         {test_noteserial_arduino_transmit_does_not_invoke_hardware_serial_flush_when_flush_parameter_is_false, "test_noteserial_arduino_transmit_does_not_invoke_hardware_serial_flush_when_flush_parameter_is_false"},
-        {test_noteserial_arduino_transmit_does_not_modify_hardware_serial_write_result_value_before_returning_to_caller, "test_noteserial_arduino_transmit_does_not_modify_hardware_serial_write_result_value_before_returning_to_caller"}
+        {test_noteserial_arduino_transmit_does_not_modify_hardware_serial_write_result_value_before_returning_to_caller, "test_noteserial_arduino_transmit_does_not_modify_hardware_serial_write_result_value_before_returning_to_caller"},
+        {test_noteserial_arduino_setBaudRate_updates_rate_used_by_reset, "test_noteserial_arduino_setBaudRate_updates_rate_used_by_reset"}
     };
 
     return TestFunction::runTests(tests, (sizeof(tests) / sizeof(TestFunction)));

--- a/test/Notecard.test.cpp
+++ b/test/Notecard.test.cpp
@@ -2956,6 +2956,97 @@ int test_notecard_responseError_does_not_modify_note_c_result_value_before_retur
   return result;
 }
 
+int test_notecard_ping_i2c_sends_card_version_request()
+{
+  int result;
+
+   // Arrange
+  ////////////
+
+  Notecard notecard;
+  J * const EXPECTED_REQUEST = reinterpret_cast<J *>(0x1979);
+  J * const EXPECTED_RESPONSE = reinterpret_cast<J *>(0x1980);
+
+  noteGetActiveInterface_Parameters.reset();
+  noteGetActiveInterface_Parameters.result = NOTE_C_INTERFACE_I2C;
+  noteNewRequest_Parameters.reset();
+  noteNewRequest_Parameters.result = EXPECTED_REQUEST;
+  noteRequestResponse_Parameters.reset();
+  noteRequestResponse_Parameters.result = EXPECTED_RESPONSE;
+  noteResponseError_Parameters.reset();
+  noteResponseError_Parameters.result = false;
+  noteDeleteResponse_Parameters.reset();
+
+   // Action
+  ///////////
+
+  const bool ACTUAL_RESULT = notecard.ping();
+
+   // Assert
+  ///////////
+
+  if (ACTUAL_RESULT
+      && noteNewRequest_Parameters.request_cache == "card.version"
+      && noteRequestResponse_Parameters.req == EXPECTED_REQUEST
+      && noteResponseError_Parameters.rsp == EXPECTED_RESPONSE
+      && noteDeleteResponse_Parameters.response == EXPECTED_RESPONSE)
+  {
+    result = 0;
+  }
+  else
+  {
+    result = static_cast<int>('p' + 'i' + 'n' + 'g');
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\tnotecard.ping() == " << ACTUAL_RESULT << ", EXPECTED: true" << std::endl;
+    std::cout << "\tnoteNewRequest_Parameters.request == " << noteNewRequest_Parameters.request_cache.c_str() << ", EXPECTED: card.version" << std::endl;
+    std::cout << "[";
+  }
+
+  return result;
+}
+
+int test_notecard_ping_i2c_returns_false_when_card_version_fails()
+{
+  int result;
+
+   // Arrange
+  ////////////
+
+  Notecard notecard;
+  J * const EXPECTED_REQUEST = reinterpret_cast<J *>(0x1981);
+
+  noteGetActiveInterface_Parameters.reset();
+  noteGetActiveInterface_Parameters.result = NOTE_C_INTERFACE_I2C;
+  noteNewRequest_Parameters.reset();
+  noteNewRequest_Parameters.result = EXPECTED_REQUEST;
+  noteRequestResponse_Parameters.reset();
+  noteRequestResponse_Parameters.result = nullptr;
+  noteDeleteResponse_Parameters.reset();
+
+   // Action
+  ///////////
+
+  const bool ACTUAL_RESULT = notecard.ping();
+
+   // Assert
+  ///////////
+
+  if (!ACTUAL_RESULT && !noteDeleteResponse_Parameters.invoked)
+  {
+    result = 0;
+  }
+  else
+  {
+    result = static_cast<int>('p' + 'i' + 'n' + 'g');
+    std::cout << "\33[31mFAILED\33[0m] " << __FILE__ << ":" << __LINE__ << std::endl;
+    std::cout << "\tnotecard.ping() == " << ACTUAL_RESULT << ", EXPECTED: false" << std::endl;
+    std::cout << "\tnoteDeleteResponse_Parameters.invoked == " << noteDeleteResponse_Parameters.invoked << ", EXPECTED: 0" << std::endl;
+    std::cout << "[";
+  }
+
+  return result;
+}
+
 int test_notecard_newCommand_does_not_modify_string_parameter_value_before_passing_to_note_c()
 {
   int result;
@@ -5109,6 +5200,8 @@ int main(void)
       {test_notecard_debugSyncStatus_does_not_modify_note_c_result_value_before_returning_to_caller, "test_notecard_debugSyncStatus_does_not_modify_note_c_result_value_before_returning_to_caller"},
       {test_notecard_responseError_does_not_modify_j_object_parameter_value_before_passing_to_note_c, "test_notecard_responseError_does_not_modify_j_object_parameter_value_before_passing_to_note_c"},
       {test_notecard_responseError_does_not_modify_note_c_result_value_before_returning_to_caller, "test_notecard_responseError_does_not_modify_note_c_result_value_before_returning_to_caller"},
+      {test_notecard_ping_i2c_sends_card_version_request, "test_notecard_ping_i2c_sends_card_version_request"},
+      {test_notecard_ping_i2c_returns_false_when_card_version_fails, "test_notecard_ping_i2c_returns_false_when_card_version_fails"},
       {test_notecard_newCommand_does_not_modify_string_parameter_value_before_passing_to_note_c, "test_notecard_newCommand_does_not_modify_string_parameter_value_before_passing_to_note_c"},
       {test_notecard_newCommand_does_not_modify_note_c_result_value_before_returning_to_caller, "test_notecard_newCommand_does_not_modify_note_c_result_value_before_returning_to_caller"},
       {test_static_callback_note_i2c_receive_invokes_notei2c_receive, "test_static_callback_note_i2c_receive_invokes_notei2c_receive"},

--- a/test/mock/NoteSerial_Mock.cpp
+++ b/test/mock/NoteSerial_Mock.cpp
@@ -5,6 +5,8 @@ NoteSerialAvailable_Parameters noteSerialAvailable_Parameters;
 NoteSerialReceive_Parameters noteSerialReceive_Parameters;
 NoteSerialReset_Parameters noteSerialReset_Parameters;
 NoteSerialTransmit_Parameters noteSerialTransmit_Parameters;
+NoteSerialSetBaudRate_Parameters noteSerialSetBaudRate_Parameters;
+NoteSerialGetBaudRate_Parameters noteSerialGetBaudRate_Parameters;
 
 NoteSerial *
 make_note_serial (
@@ -95,4 +97,31 @@ NoteSerial_Mock::transmit (
 
     // Return user-supplied result
     return noteSerialTransmit_Parameters.result;
+}
+
+bool
+NoteSerial_Mock::setBaudRate (
+    uint32_t rate_
+)
+{
+    // Record invocation(s)
+    ++noteSerialSetBaudRate_Parameters.invoked;
+
+    // Stash parameter(s)
+    noteSerialSetBaudRate_Parameters.rate = rate_;
+
+    // Return user-supplied result
+    return noteSerialSetBaudRate_Parameters.result;
+}
+
+uint32_t
+NoteSerial_Mock::getBaudRate (
+    void
+) const
+{
+    // Record invocation(s)
+    ++noteSerialGetBaudRate_Parameters.invoked;
+
+    // Return user-supplied result
+    return noteSerialGetBaudRate_Parameters.result;
 }

--- a/test/mock/NoteSerial_Mock.hpp
+++ b/test/mock/NoteSerial_Mock.hpp
@@ -14,6 +14,8 @@ public:
     char receive(void) override;
     bool reset(void) override;
     size_t transmit(uint8_t * buffer, size_t size, bool flush) override;
+    bool setBaudRate(uint32_t rate) override;
+    uint32_t getBaudRate(void) const override;
 };
 
 template <typename T>
@@ -114,10 +116,49 @@ struct NoteSerialTransmit_Parameters {
     size_t result;
 };
 
+struct NoteSerialSetBaudRate_Parameters {
+    NoteSerialSetBaudRate_Parameters(
+        void
+    ) :
+        invoked(0),
+        rate(0),
+        result(false)
+    { }
+    void reset (
+        void
+    ) {
+        invoked = 0;
+        rate = 0;
+        result = false;
+    }
+    size_t invoked;
+    uint32_t rate;
+    bool result;
+};
+
+struct NoteSerialGetBaudRate_Parameters {
+    NoteSerialGetBaudRate_Parameters(
+        void
+    ) :
+        invoked(0),
+        result(0)
+    { }
+    void reset (
+        void
+    ) {
+        invoked = 0;
+        result = 0;
+    }
+    mutable size_t invoked;
+    uint32_t result;
+};
+
 extern MakeNoteSerial_Parameters<HardwareSerial> make_note_serial_Parameters;
 extern NoteSerialAvailable_Parameters noteSerialAvailable_Parameters;
 extern NoteSerialReceive_Parameters noteSerialReceive_Parameters;
 extern NoteSerialReset_Parameters noteSerialReset_Parameters;
 extern NoteSerialTransmit_Parameters noteSerialTransmit_Parameters;
+extern NoteSerialSetBaudRate_Parameters noteSerialSetBaudRate_Parameters;
+extern NoteSerialGetBaudRate_Parameters noteSerialGetBaudRate_Parameters;
 
 #endif // MOCK_NOTE_SERIAL_HPP

--- a/test/mock/mock-arduino.cpp
+++ b/test/mock/mock-arduino.cpp
@@ -134,7 +134,7 @@ HardwareSerial::available (
 
 void
 HardwareSerial::begin (
-    unsigned int baud
+    uint32_t baud
 ) {
     // Record invocation(s)
     ++hardwareSerialBegin_Parameters.invoked;
@@ -210,7 +210,7 @@ SoftwareSerial::available (
 
 void
 SoftwareSerial::begin (
-    unsigned int baud
+    uint32_t baud
 ) {
     // Record invocation(s)
     ++softwareSerialBegin_Parameters.invoked;

--- a/test/mock/mock-arduino.hpp
+++ b/test/mock/mock-arduino.hpp
@@ -159,7 +159,7 @@ struct StreamPrint_Parameters {
 struct HardwareSerial : public Stream {
     operator bool();
     unsigned int available (void);
-    void begin(unsigned int baud);
+    void begin(uint32_t baud);
     void end(void);
     void flush(void);
     char read (void);
@@ -198,7 +198,7 @@ struct HardwareSerialBegin_Parameters {
         invoked = 0;
         baud = 0;
     }
-    unsigned int baud;
+    uint32_t baud;
     size_t invoked;
 };
 
@@ -297,7 +297,7 @@ struct HardwareSerialWrite_Parameters {
 struct SoftwareSerial : public Stream {
     operator bool();
     unsigned int available (void);
-    void begin(unsigned int baud);
+    void begin(uint32_t baud);
     void end(void);
     void flush(void);
     char read (void);
@@ -336,7 +336,7 @@ struct SoftwareSerialBegin_Parameters {
         invoked = 0;
         baud = 0;
     }
-    unsigned int baud;
+    uint32_t baud;
     size_t invoked;
 };
 

--- a/test/mock/mock-note-c-note.c
+++ b/test/mock/mock-note-c-note.c
@@ -1,10 +1,13 @@
 #include "mock-parameters.hpp"
 
 JAddIntToObject_Parameters jAddIntToObject_Parameters;
+JAddStringToObject_Parameters jAddStringToObject_Parameters;
+JGetString_Parameters jGetString_Parameters;
 NoteDebug_Parameters noteDebug_Parameters;
 NoteDebugSyncStatus_Parameters noteDebugSyncStatus_Parameters;
 NoteDelayMs_Parameters noteDelayMs_Parameters;
 NoteDeleteResponse_Parameters noteDeleteResponse_Parameters;
+NoteGetActiveInterface_Parameters noteGetActiveInterface_Parameters;
 NoteGetFnI2C_Parameters noteGetFnI2C_Parameters;
 NoteGetFnSerial_Parameters noteGetFnSerial_Parameters;
 NoteGetMs_Parameters noteGetMs_Parameters;
@@ -49,6 +52,47 @@ JAddIntToObject (
     } else {
         return jAddIntToObject_Parameters.result[(jAddIntToObject_Parameters.invoked - 1)];
     }
+}
+
+J *
+JAddStringToObject (
+    J * const object_,
+    const char * const name_,
+    const char * const string_
+) {
+    // Record invocation(s)
+    ++jAddStringToObject_Parameters.invoked;
+
+    // Stash parameter(s)
+    jAddStringToObject_Parameters.object.push_back(object_);
+    jAddStringToObject_Parameters.name.push_back(name_ ? name_ : "");
+    jAddStringToObject_Parameters.string.push_back(string_ ? string_ : "");
+
+    // Return user-supplied result
+    if (jAddStringToObject_Parameters.result.size() < jAddStringToObject_Parameters.invoked) {
+        return jAddStringToObject_Parameters.default_result;
+    } else {
+        return jAddStringToObject_Parameters.result[(jAddStringToObject_Parameters.invoked - 1)];
+    }
+}
+
+char *
+JGetString (
+    J * json_,
+    const char * field_
+) {
+    // Record invocation(s)
+    ++jGetString_Parameters.invoked;
+
+    // Stash parameter(s)
+    jGetString_Parameters.json = json_;
+    jGetString_Parameters.field = field_;
+    if (field_) {
+        jGetString_Parameters.field_cache = field_;
+    }
+
+    // Return user-supplied result
+    return const_cast<char *>(jGetString_Parameters.result);
 }
 
 void
@@ -179,6 +223,17 @@ void NoteGetFnSerial(serialResetFn *resetFn, serialTransmitFn *transmitFn,
     if (receiveFn) {
         *receiveFn = noteGetFnSerial_Parameters.receiveFn_result;
     }
+}
+
+int
+NoteGetActiveInterface(
+    void
+) {
+    // Record invocation(s)
+    ++noteGetActiveInterface_Parameters.invoked;
+
+    // Return user-supplied result
+    return noteGetActiveInterface_Parameters.result;
 }
 
 uint32_t

--- a/test/mock/mock-parameters.hpp
+++ b/test/mock/mock-parameters.hpp
@@ -50,6 +50,58 @@ struct JAddIntToObject_Parameters {
     J *default_result;
 };
 
+struct JAddStringToObject_Parameters {
+    JAddStringToObject_Parameters(
+        void
+    ) :
+        invoked(0),
+        default_result(nullptr)
+    { }
+    void
+    reset (
+        void
+    ) {
+        invoked = 0;
+        object.clear();
+        name.clear();
+        string.clear();
+        result.clear();
+        default_result = nullptr;
+    }
+    size_t invoked;
+    std::vector<J *> object;
+    std::vector<std::string> name;
+    std::vector<std::string> string;
+    std::vector<J *> result;
+    J *default_result;
+};
+
+struct JGetString_Parameters {
+    JGetString_Parameters(
+        void
+    ) :
+        invoked(0),
+        json(nullptr),
+        field(nullptr),
+        result("")
+    { }
+    void
+    reset (
+        void
+    ) {
+        invoked = 0;
+        json = nullptr;
+        field = nullptr;
+        field_cache.clear();
+        result = "";
+    }
+    size_t invoked;
+    J *json;
+    const char *field;
+    std::string field_cache;
+    const char *result;
+};
+
 struct NoteDebug_Parameters {
     NoteDebug_Parameters(
         void
@@ -236,6 +288,24 @@ struct NoteGetMs_Parameters {
     size_t invoked;
     uint32_t default_result;
     std::vector<uint32_t> result;
+};
+
+struct NoteGetActiveInterface_Parameters {
+    NoteGetActiveInterface_Parameters(
+        void
+    ) :
+        invoked(0),
+        result(NOTE_C_INTERFACE_NONE)
+    { }
+    void
+    reset (
+        void
+    ) {
+        invoked = 0;
+        result = NOTE_C_INTERFACE_NONE;
+    }
+    size_t invoked;
+    int result;
 };
 
 struct NoteNewCommand_Parameters {
@@ -701,10 +771,13 @@ struct NoteSetUserAgent_Parameters {
 };
 
 extern JAddIntToObject_Parameters jAddIntToObject_Parameters;
+extern JAddStringToObject_Parameters jAddStringToObject_Parameters;
+extern JGetString_Parameters jGetString_Parameters;
 extern NoteDebug_Parameters noteDebug_Parameters;
 extern NoteDebugSyncStatus_Parameters noteDebugSyncStatus_Parameters;
 extern NoteDelayMs_Parameters noteDelayMs_Parameters;
 extern NoteDeleteResponse_Parameters noteDeleteResponse_Parameters;
+extern NoteGetActiveInterface_Parameters noteGetActiveInterface_Parameters;
 extern NoteGetFnI2C_Parameters noteGetFnI2C_Parameters;
 extern NoteGetFnSerial_Parameters noteGetFnSerial_Parameters;
 extern NoteGetMs_Parameters noteGetMs_Parameters;

--- a/test/run_all_tests.sh
+++ b/test/run_all_tests.sh
@@ -19,6 +19,7 @@ if [ 0 -eq $all_tests_result ]; then
   echo && echo -e "${YELLOW}Compiling and running Notecard Test Suite...${DEFAULT}"
   g++ -fprofile-arcs -ftest-coverage -Wall -Wextra -Werror -Wpedantic -Wno-deprecated-declarations -std=c++11 -O0 -g \
     src/Notecard.cpp \
+    src/NotecardPing.cpp \
     test/Notecard.test.cpp \
     test/mock/mock-arduino.cpp \
     test/mock/mock-note-c-note.c \


### PR DESCRIPTION
Supersedes #165 with the original Notecard.ping() work plus cleanup needed to make it mergeable.\n\nChanges included here:\n- keep the public Notecard.ping() API from #165\n- replace the unavailable NotePing() dependency with a local card.version probe compatible with the embedded note-c version\n- preserve high serial baud rates with uint32_t storage/API so AVR does not truncate rates like 115200/460800\n- compile NotecardPing.cpp in the host test suite and add focused ping/baud regression coverage\n- document ping() in README and Arduino keywords metadata\n\nValidation run locally:\n- docker run --rm --volume $(pwd):/note-arduino/ --workdir /note-arduino/ --entrypoint ./test/run_all_tests.sh --user root ghcr.io/blues/note_arduino_ci:latest\n- docker run --rm --volume $(pwd):/note-arduino/ --workdir /note-arduino/ --entrypoint ./scripts/build_example.sh ghcr.io/blues/note_arduino_ci:latest arduino:avr:uno ./examples/Example1_NotecardBasics/Example1_NotecardBasics.ino\n- docker run --rm --volume $(pwd):/note-arduino/ --workdir /note-arduino/ --entrypoint ./scripts/build_example.sh ghcr.io/blues/note_arduino_ci:latest arduino:samd:mkrzero ./examples/Example1_NotecardBasics/Example1_NotecardBasics.ino